### PR TITLE
Add nominal mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ public class VerbNetParserTest {
         LightVerbMapper verbMapper = LightVerbMapper.fromMappingsPath("semparse/lvm.tsv", verbNet);
         // aligner that uses PropBank VerbNet mappings and heuristics to align PropBank roles with VerbNet thematic roles
         VerbNetAligner aligner = VerbNetAligner.of("semparse/pbvn-mappings.json", "semparse/unified-frames.bin");
+        VnPredicateDetector predicateDetector = new DefaultVnPredicateDetector(classifier, verbMapper);
 
         // simplifying facade over the above components
-        VerbNetParser parser = new VerbNetParser(classifier, roleLabeler, aligner, verbMapper);
+        VerbNetParser parser = new VerbNetParser(predicateDetector, classifier, roleLabeler, aligner);
 
         VerbNetParse parse = parser.parse("John ate an apple");
         System.out.println(parse); // Take In[EVENT(E1 = VnClassXml(verbNetId=eat-39.1)), Agent(A0[John]), Patient(A1[an apple])]

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.github.semlink</groupId>
     <artifactId>semparse</artifactId>
-    <version>0.0.4-SNAPSHOT</version>
+    <version>0.0.5-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>SemParse</name>

--- a/semparse-core/pom.xml
+++ b/semparse-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>semparse</artifactId>
         <groupId>io.github.semlink</groupId>
-        <version>0.0.4-SNAPSHOT</version>
+        <version>0.0.5-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/semparse-core/src/main/java/io/github/semlink/parser/DefaultVnPredicateDetector.java
+++ b/semparse-core/src/main/java/io/github/semlink/parser/DefaultVnPredicateDetector.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 James Gung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.semlink.parser;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import io.github.clearwsd.DefaultSensePrediction;
+import io.github.clearwsd.SensePrediction;
+import io.github.clearwsd.type.DepNode;
+import io.github.clearwsd.type.DepTree;
+import io.github.clearwsd.type.FeatureType;
+import io.github.semlink.app.Span;
+import io.github.semlink.verbnet.VnClass;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+
+/**
+ * Default {@link VnPredicateDetector} implementation.
+ *
+ * @author jgung
+ */
+@AllArgsConstructor
+public class DefaultVnPredicateDetector implements VnPredicateDetector {
+
+    private VerbNetSenseClassifier verbNetClassifier;
+    private PredicateMapper<VnClass> lightVerbMapper;
+    private List<PredicateMapper<VnClass>> tokenMappers;
+
+    @SafeVarargs
+    public DefaultVnPredicateDetector(VerbNetSenseClassifier verbNetClassifier, PredicateMapper<VnClass> lightVerbMapper,
+                                      PredicateMapper<VnClass>... nominalMappers) {
+        this.verbNetClassifier = verbNetClassifier;
+        this.lightVerbMapper = lightVerbMapper;
+        this.tokenMappers = Arrays.stream(nominalMappers).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<SensePrediction<VnClass>> detectPredicates(@NonNull DepTree depTree) {
+        List<SensePrediction<VnClass>> senses = verbNetClassifier.predict(depTree);
+
+        Map<Integer, SensePrediction<VnClass>> predictions = senses.stream()
+                .collect(Collectors.toMap(SensePrediction::index, Function.identity()));
+
+        for (SensePrediction<VnClass> sense : senses) {
+            DepNode verb = depTree.get(sense.index());
+
+            // map light verbs to nominal props
+            lightVerbMapper.mapPredicate(verb).map(span -> toSensePrediction(span, depTree))
+                    .ifPresent(prediction -> {
+                        if (!predictions.containsKey(prediction.index())) {
+                            predictions.put(prediction.index(), prediction);
+                        }
+                    });
+        }
+
+        for (PredicateMapper<VnClass> mapper : tokenMappers) {
+            for (DepNode depNode : depTree) {
+                mapper.mapPredicate(depNode).map(span -> toSensePrediction(span, depTree))
+                        .ifPresent(prediction -> {
+                            if (!predictions.containsKey(prediction.index())) {
+                                predictions.put(prediction.index(), prediction);
+                            }
+                        });
+            }
+        }
+
+        return predictions.entrySet().stream()
+                .sorted(Comparator.comparing(Map.Entry::getKey))
+                .map(Map.Entry::getValue).collect(Collectors.toList());
+    }
+
+    private static SensePrediction<VnClass> toSensePrediction(Span<VnClass> span, DepTree depTree) {
+        return new DefaultSensePrediction<>(span.startIndex(),
+                span.get(depTree).stream()
+                        .map(node -> (String) node.feature(FeatureType.Text))
+                        .collect(Collectors.joining(" ")), span.label().verbNetId().classId(),
+                span.label());
+    }
+
+}

--- a/semparse-core/src/main/java/io/github/semlink/parser/DefaultVnPredicateDetector.java
+++ b/semparse-core/src/main/java/io/github/semlink/parser/DefaultVnPredicateDetector.java
@@ -58,6 +58,8 @@ public class DefaultVnPredicateDetector implements VnPredicateDetector {
         List<SensePrediction<VnClass>> senses = verbNetClassifier.predict(depTree);
 
         Map<Integer, SensePrediction<VnClass>> predictions = senses.stream()
+                // TODO: VerbNet classifier should ideally have this kind of check
+                .filter(sense -> !depTree.get(sense.index()).feature(FeatureType.Dep).toString().equalsIgnoreCase("nmod"))
                 .collect(Collectors.toMap(SensePrediction::index, Function.identity()));
 
         for (SensePrediction<VnClass> sense : senses) {

--- a/semparse-core/src/main/java/io/github/semlink/parser/NominalMapper.java
+++ b/semparse-core/src/main/java/io/github/semlink/parser/NominalMapper.java
@@ -47,11 +47,13 @@ public class NominalMapper implements PredicateMapper<VnClass> {
 
     @Override
     public Optional<Span<VnClass>> mapPredicate(@NonNull DepNode child) {
-        String lemma = child.feature(FeatureType.Lemma);
-        VnMember member = mappings.get(lemma);
-        if (!child.feature(FeatureType.Pos).toString().toUpperCase().startsWith("N")) {
+        if (!child.feature(FeatureType.Pos).toString().toUpperCase().startsWith("N")
+                || child.feature(FeatureType.Dep).toString().toUpperCase().equals("COMPOUND")) {
             return Optional.empty();
         }
+
+        String lemma = child.feature(FeatureType.Lemma);
+        VnMember member = mappings.get(lemma);
         if (null != member) {
             child.addFeature(FeatureType.Lemma, member.lemma);
             return Optional.of(new Span<>(member.vnClass, child.index(), child.index()));

--- a/semparse-core/src/main/java/io/github/semlink/parser/NominalMapper.java
+++ b/semparse-core/src/main/java/io/github/semlink/parser/NominalMapper.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 James Gung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.semlink.parser;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import io.github.clearwsd.type.DepNode;
+import io.github.clearwsd.type.FeatureType;
+import io.github.semlink.app.Span;
+import io.github.semlink.verbnet.VnClass;
+import io.github.semlink.verbnet.VnIndex;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import static io.github.semlink.util.TsvUtils.readTsv;
+
+/**
+ * Check if an argument of the input corresponds to a nominal predicate, and map to the corresponding nominal propositional
+ * structure if so.
+ *
+ * @author jgung
+ */
+@Slf4j
+@AllArgsConstructor
+public class NominalMapper implements PredicateMapper<VnClass> {
+
+    private Map<String, VnMember> mappings;
+
+    @Override
+    public Optional<Span<VnClass>> mapPredicate(@NonNull DepNode child) {
+        String lemma = child.feature(FeatureType.Lemma);
+        VnMember member = mappings.get(lemma);
+        if (!child.feature(FeatureType.Pos).toString().toUpperCase().startsWith("N")) {
+            return Optional.empty();
+        }
+        if (null != member) {
+            child.addFeature(FeatureType.Lemma, member.lemma);
+            return Optional.of(new Span<>(member.vnClass, child.index(), child.index()));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Load mappings in the format: noun TAB verb TAB class, e.g. "adjustment   adjust  26.9".
+     *
+     * @return map from verb lemma, to a map from noun lemmas to VerbNet classes
+     */
+    public static NominalMapper fromMappingsPath(@NonNull String mappingsPath,
+                                                 @NonNull VnIndex verbNet) {
+        try {
+            Map<String, VnMember> result = new HashMap<>();
+            for (String[] fields : readTsv(mappingsPath)) {
+                if (fields.length < 3) {
+                    continue;
+                }
+                String noun = fields[0];
+                String verbLemma = fields[1];
+                String verbClasses = fields[2];
+                for (String verbClass : verbClasses.split(" ")) {
+                    VnClass byId = verbNet.getById(verbClass);
+                    if (null == byId) {
+                        log.warn("Missing VerbNet class for nominal mapping: {}-{}", verbLemma, verbClass);
+                        continue;
+                    }
+                    if (verbNet.getMembersByLemma(verbLemma).stream()
+                            .map(io.github.semlink.verbnet.VnMember::verbClass)
+                            .collect(Collectors.toSet()).contains(byId)) {
+                        result.put(noun, new VnMember(byId, verbLemma));
+                        break;
+                    }
+                }
+            }
+            return new NominalMapper(result);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AllArgsConstructor
+    private static class VnMember {
+        private VnClass vnClass;
+        private String lemma;
+    }
+
+}

--- a/semparse-core/src/main/java/io/github/semlink/parser/VerbNetParse.java
+++ b/semparse-core/src/main/java/io/github/semlink/parser/VerbNetParse.java
@@ -37,7 +37,7 @@ public class VerbNetParse {
 
     private DepTree tree;
     private List<String> tokens;
-    private List<DefaultVerbNetProp> props = new ArrayList<>();
+    private List<VerbNetProp> props = new ArrayList<>();
 
     @Override
     public String toString() {

--- a/semparse-core/src/main/java/io/github/semlink/parser/VerbNetParser.java
+++ b/semparse-core/src/main/java/io/github/semlink/parser/VerbNetParser.java
@@ -23,9 +23,9 @@ import java.util.stream.Collectors;
 import io.github.clearwsd.SensePrediction;
 import io.github.clearwsd.type.DepTree;
 import io.github.clearwsd.type.FeatureType;
-import io.github.semlink.verbnet.VnClass;
 import io.github.semlink.propbank.type.PropBankArg;
 import io.github.semlink.semlink.VerbNetAligner;
+import io.github.semlink.verbnet.VnClass;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
@@ -70,7 +70,7 @@ public class VerbNetParser {
                         .map(node -> (String) node.feature(FeatureType.Text))
                         .collect(Collectors.toList()))
                 .tree(parsed)
-                .props(vnProps.stream().map(prop -> (DefaultVerbNetProp) prop).collect(Collectors.toList()));
+                .props(vnProps);
     }
 
     /**

--- a/semparse-core/src/main/java/io/github/semlink/parser/VerbNetParser.java
+++ b/semparse-core/src/main/java/io/github/semlink/parser/VerbNetParser.java
@@ -16,11 +16,11 @@
 
 package io.github.semlink.parser;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import io.github.clearwsd.SensePrediction;
+import io.github.clearwsd.parser.NlpParser;
 import io.github.clearwsd.type.DepTree;
 import io.github.clearwsd.type.FeatureType;
 import io.github.semlink.propbank.type.PropBankArg;
@@ -41,16 +41,17 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 public class VerbNetParser {
 
-    private VerbNetSenseClassifier verbNetClassifier;
-
+    private VnPredicateDetector vnPredicateDetector;
+    private NlpParser parser;
     private VerbNetSemParser verbNetRoleLabeler;
 
-    public VerbNetParser(@NonNull VerbNetSenseClassifier verbNetClassifier,
+    public VerbNetParser(@NonNull VnPredicateDetector verbNetClassifier,
+                         @NonNull NlpParser parser,
                          @NonNull SemanticRoleLabeler<PropBankArg> roleLabeler,
-                         @NonNull VerbNetAligner aligner,
-                         @NonNull PredicateMapper<VnClass> predicateMapper) {
-        this.verbNetClassifier = verbNetClassifier;
-        this.verbNetRoleLabeler = new VerbNetSemParser(roleLabeler, aligner, Collections.singletonList(predicateMapper));
+                         @NonNull VerbNetAligner aligner) {
+        this.vnPredicateDetector = verbNetClassifier;
+        this.parser = parser;
+        this.verbNetRoleLabeler = new VerbNetSemParser(roleLabeler, aligner);
     }
 
     /**
@@ -81,7 +82,7 @@ public class VerbNetParser {
      * @return VerbNet semantic parse
      */
     public VerbNetParse parse(@NonNull DepTree parsed) {
-        List<SensePrediction<VnClass>> senses = verbNetClassifier.predict(parsed);
+        List<SensePrediction<VnClass>> senses = vnPredicateDetector.detectPredicates(parsed);
         return parse(parsed, senses);
     }
 
@@ -93,8 +94,8 @@ public class VerbNetParser {
      * @return VerbNet semantic parse
      */
     public VerbNetParse parse(@NonNull String sentence) {
-        List<String> tokens = verbNetClassifier.tokenize(sentence);
-        DepTree depTree = verbNetClassifier.parse(tokens);
+        List<String> tokens = parser.tokenize(sentence);
+        DepTree depTree = parser.parse(tokens);
         return parse(depTree);
     }
 

--- a/semparse-core/src/main/java/io/github/semlink/parser/VerbNetProp.java
+++ b/semparse-core/src/main/java/io/github/semlink/parser/VerbNetProp.java
@@ -21,11 +21,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import io.github.semlink.verbnet.VnClass;
 import io.github.semlink.app.Span;
 import io.github.semlink.propbank.type.FunctionTag;
 import io.github.semlink.propbank.type.PropBankArg;
+import io.github.semlink.semlink.SemlinkRole;
+import io.github.semlink.verbnet.VnClass;
 import io.github.semlink.verbnet.semantics.Event;
+import io.github.semlink.verbnet.semantics.SemanticPredicate;
 import io.github.semlink.verbnet.type.ThematicRoleType;
 import lombok.NonNull;
 
@@ -35,6 +37,21 @@ import lombok.NonNull;
  * @author jamesgung
  */
 public interface VerbNetProp {
+
+    /**
+     * Original list of tokens from which this proposition was extracted.
+     */
+    List<String> tokens();
+
+    /**
+     * All VerbNet semantic predicates extracted for this proposition.
+     */
+    List<SemanticPredicate> predicates();
+
+    /**
+     * Proposition containing spans over text with associated {@link SemlinkRole roles}.
+     */
+    Proposition<VnClass, SemlinkRole> proposition();
 
     /**
      * Return the {@link VnClass} for this proposition.

--- a/semparse-core/src/main/java/io/github/semlink/parser/VerbNetSemParser.java
+++ b/semparse-core/src/main/java/io/github/semlink/parser/VerbNetSemParser.java
@@ -18,26 +18,24 @@ package io.github.semlink.parser;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import io.github.clearwsd.SensePrediction;
 import io.github.clearwsd.type.DepNode;
 import io.github.clearwsd.type.DepTree;
-import io.github.semlink.app.Span;
 import io.github.semlink.propbank.type.FunctionTag;
 import io.github.semlink.propbank.type.PropBankArg;
 import io.github.semlink.semlink.VerbNetAligner;
 import io.github.semlink.verbnet.VnClass;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
-import lombok.Setter;
-import lombok.experimental.Accessors;
 
 import static io.github.semlink.parser.SemanticRoleLabeler.convert;
 
 /**
- * VerbNet (shallow) semantic parser. Performs predicate mapping (light verb to nominal predicate), semantic role labeling and
- * alignment of roles to VerbNet thematic roles/frames.
+ * VerbNet (shallow) semantic parser. Performs semantic role labeling and alignment of roles to VerbNet thematic roles/frames.
  *
  * @author jgung
  */
@@ -46,14 +44,9 @@ public class VerbNetSemParser {
 
     private SemanticRoleLabeler<PropBankArg> roleLabeler;
     private VerbNetAligner aligner;
-    private List<PredicateMapper<VnClass>> predicateMappers;
 
     /**
      * Perform a shallow semantic parse on the input dependency parse for a given list of predicates.
-     *
-     * <p/> 1. Identify potential light verbs and heavy nouns
-     * <p/> 2. Perform semantic role labeling with respect to identified verbal and nominal predicates
-     * <p/> 3. If resulting roles are correct, prefer heavy noun predicates over light verb predicates
      *
      * @param parsed dependency parse
      * @param senses predicates with sense predictions
@@ -61,62 +54,26 @@ public class VerbNetSemParser {
      */
     public List<VerbNetProp> extractProps(@NonNull DepTree parsed,
                                           @NonNull List<SensePrediction<VnClass>> senses) {
-        List<Integer> predicateIndices = new ArrayList<>();
-        List<VerbAndNoun> lightVerbs = new ArrayList<>();
+        Map<Integer, SensePrediction<VnClass>> sensesByIndex = senses.stream()
+                .collect(Collectors.toMap(SensePrediction::index, Function.identity()));
 
-        for (SensePrediction<VnClass> sense : senses) {
-            DepNode verb = parsed.get(sense.index());
-
-            // map light verbs to nominal props
-            Optional<Span<VnClass>> possibleHeavyNoun = predicateMappers.stream()
-                    .map(mapper -> mapper.mapPredicate(verb))
-                    .filter(Optional::isPresent)
-                    .map(Optional::get)
-                    .findFirst();
-
-            VerbAndNoun instance = new VerbAndNoun()
-                    .verbIndex(predicateIndices.size())
-                    .verbClass(sense.sense());
-
-            predicateIndices.add(sense.index());
-            lightVerbs.add(instance);
-
-            possibleHeavyNoun.ifPresent(heavyNoun -> {
-                instance.nominalIndex(predicateIndices.size())
-                        .nominalClass(heavyNoun.label());
-                predicateIndices.add(heavyNoun.startIndex());
-            });
-        }
-
-        List<Proposition<DepNode, PropBankArg>> props = roleLabeler.parse(parsed, predicateIndices);
+        List<Proposition<DepNode, PropBankArg>> props = roleLabeler.parse(parsed, senses.stream()
+                .map(SensePrediction::index)
+                .collect(Collectors.toList()));
 
         List<Proposition<VnClass, PropBankArg>> filtered = new ArrayList<>();
-        for (VerbAndNoun lv : lightVerbs) {
-            if (lv.nominalClass == null) {
-                filtered.add(convert(props.get(lv.verbIndex), lv.verbClass));
+        for (Proposition<DepNode, PropBankArg> prop : props) {
+            if (prop.relSpan() == null || prop.arguments().spans().size() == 1) {
                 continue;
             }
-
-            Proposition<DepNode, PropBankArg> nominalProp = props.get(lv.nominalIndex);
-            if (nominalProp.arguments().spans().stream().anyMatch(arg -> arg.label().getFunctionTag() == FunctionTag.LVB)) {
-                // exclude any props without LVB annotated–this indicates the role labels were not correct
-                filtered.add(convert(nominalProp, lv.nominalClass));
-            } else {
-                // fallback to verbal proposition if nominal event structure not parsed correctly
-                filtered.add(convert(props.get(lv.verbIndex), lv.verbClass));
+            if (prop.arguments().spans().stream().anyMatch(arg -> arg.label().getFunctionTag() == FunctionTag.PRR
+                    && prop.arguments().spans().size() <= 2)) {
+                continue;
             }
+            filtered.add(convert(prop, sensesByIndex.get(prop.relIndex()).sense()));
         }
 
         return aligner.align(parsed, filtered);
-    }
-
-    @Setter
-    @Accessors(fluent = true)
-    private static class VerbAndNoun {
-        int verbIndex;
-        int nominalIndex;
-        VnClass verbClass;
-        VnClass nominalClass;
     }
 
 }

--- a/semparse-core/src/main/java/io/github/semlink/parser/VerbNetSemParser.java
+++ b/semparse-core/src/main/java/io/github/semlink/parser/VerbNetSemParser.java
@@ -19,16 +19,15 @@ package io.github.semlink.parser;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import io.github.clearwsd.SensePrediction;
 import io.github.clearwsd.type.DepNode;
 import io.github.clearwsd.type.DepTree;
-import io.github.semlink.verbnet.VnClass;
 import io.github.semlink.app.Span;
 import io.github.semlink.propbank.type.FunctionTag;
 import io.github.semlink.propbank.type.PropBankArg;
 import io.github.semlink.semlink.VerbNetAligner;
+import io.github.semlink.verbnet.VnClass;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
@@ -108,8 +107,7 @@ public class VerbNetSemParser {
             }
         }
 
-        List<DefaultVerbNetProp> vnProps = aligner.align(parsed, filtered);
-        return vnProps.stream().map(prop -> (VerbNetProp) prop).collect(Collectors.toList());
+        return aligner.align(parsed, filtered);
     }
 
     @Setter

--- a/semparse-core/src/main/java/io/github/semlink/parser/VnPredicateDetector.java
+++ b/semparse-core/src/main/java/io/github/semlink/parser/VnPredicateDetector.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 James Gung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.semlink.parser;
+
+import java.util.List;
+
+import io.github.clearwsd.SensePrediction;
+import io.github.clearwsd.type.DepTree;
+import io.github.semlink.verbnet.VnClass;
+import lombok.NonNull;
+
+/**
+ * VerbNet predicate detector.
+ *
+ * @author jgung
+ */
+public interface VnPredicateDetector {
+
+    /**
+     * Identify VerbNet sense-tagged predicates from a dependency parse.
+     *
+     * @param depTree dependency parsed sentence
+     * @return predicated predicates and their sense tags
+     */
+    List<SensePrediction<VnClass>> detectPredicates(@NonNull DepTree depTree);
+
+}

--- a/semparse-core/src/main/java/io/github/semlink/semlink/PredicateMappingUtil.java
+++ b/semparse-core/src/main/java/io/github/semlink/semlink/PredicateMappingUtil.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2019 James Gung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.semlink.semlink;
+
+import com.google.common.base.Strings;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.github.semlink.propbank.frames.Frameset;
+import io.github.semlink.propbank.frames.PbRole;
+import io.github.semlink.propbank.frames.Roleset;
+import io.github.semlink.propbank.frames.RolesetAlias;
+import io.github.semlink.propbank.frames.VerbNetRole;
+import io.github.semlink.verbnet.DefaultVnIndex;
+import io.github.semlink.verbnet.VnIndex;
+import lombok.experimental.UtilityClass;
+
+import static io.github.semlink.propbank.frames.FramesetFactory.deserializeFrames;
+
+/**
+ * Utilities used to write nominal predicate mappings to VerbNet classes to a file.
+ *
+ * @author jgung
+ */
+@UtilityClass
+public class PredicateMappingUtil {
+
+    /**
+     * Write mappings from nouns to VerbNet classes ordered based on frequency of roleset and VerbNet class.
+     *
+     * @param rsCounts   PB roleset counts by lemma
+     * @param vnCounts   VN class counts by lemma
+     * @param frames     frames
+     * @param outputPath output path
+     */
+    public static void writeNominalPredicateMappings(Map<String, Map<String, Integer>> rsCounts,
+                                                     Map<String, Map<String, Integer>> vnCounts,
+                                                     List<Frameset> frames,
+                                                     String outputPath) throws FileNotFoundException {
+        List<String> fields = new ArrayList<>();
+        VnIndex vnIndex = new DefaultVnIndex();
+        for (Frameset frameset : frames) {
+            for (Roleset roleset : frameset.rolesets()) {
+                String predicateLemma = roleset.predicate().lemma();
+                Map<String, Integer> allCounts = rsCounts.getOrDefault(predicateLemma, new HashMap<>());
+                Map<String, Integer> verbNetCounts = vnCounts.getOrDefault(predicateLemma, new HashMap<>());
+
+                Optional<RolesetAlias> verbAlias = roleset.aliases().stream()
+                        .filter(a -> a.pos() == RolesetAlias.AliasPos.V)
+                        .filter(a -> !Strings.isNullOrEmpty(a.verbnet()))
+                        .findFirst();
+                String verbNetMappings;
+                String lemma;
+                if (!verbAlias.isPresent()) {
+                    List<String> roles = roleset.roles().roles().stream()
+                            .map(PbRole::verbNetRoles)
+                            .flatMap(List::stream)
+                            .map(VerbNetRole::verbNetClass)
+                            .filter(s -> !Strings.isNullOrEmpty(s))
+                            .distinct()
+                            .filter(v -> vnIndex.getById(v) != null)
+                            .sorted(Comparator.comparing(s -> -verbNetCounts.getOrDefault(s, 0)))
+                            .collect(Collectors.toList());
+                    if (roles.isEmpty()) {
+                        continue;
+                    }
+                    verbNetMappings = String.join(" ", roles);
+                    lemma = roleset.aliases().stream()
+                            .filter(a -> a.pos() == RolesetAlias.AliasPos.V)
+                            .filter(a -> !Strings.isNullOrEmpty(a.verbnet()))
+                            .map(RolesetAlias::lemma)
+                            .findFirst().orElse(roleset.id().substring(0, roleset.id().length() - 3));
+                } else {
+                    verbNetMappings = verbAlias.get().verbnet();
+                    lemma = verbAlias.get().lemma();
+                }
+                if (verbNetMappings.length() < 2) {
+                    continue;
+                }
+                for (RolesetAlias nominal : roleset.aliases().stream()
+                        .filter(a -> a.pos() == RolesetAlias.AliasPos.N)
+                        .collect(Collectors.toList())) {
+                    if (allCounts.getOrDefault(roleset.id(), 0)
+                            == allCounts.values().stream().mapToInt(i -> i).max().orElse(0)) {
+                        fields.add(nominal.lemma() + "\t" + lemma + "\t" + verbNetMappings
+                                + "\t" + allCounts.getOrDefault(roleset.id(), 0));
+                    }
+                }
+            }
+        }
+        Collections.sort(fields);
+
+        try (PrintWriter printWriter = new PrintWriter(outputPath)) {
+            fields.forEach(printWriter::println);
+        }
+    }
+
+    /**
+     * Write a JSON file with most frequent senses for rolesets from a CoNLL-2012-formatted file.
+     * <p/>
+     * <code>
+     * {
+     * "cancel": {
+     * "cancel.01": 11
+     * },
+     * "prepare": {
+     * "prepare.01": 4,
+     * "prepare.02": 21
+     * },
+     * ...
+     * </code>
+     *
+     * @param trainingPath CoNLL SRL input path
+     * @return roleset frequencies by lemma
+     */
+    public static Map<String, Map<String, Integer>> pbMostFrequent(String trainingPath) throws IOException {
+        Map<String, Map<String, Integer>> rolesetCounts = new HashMap<>();
+        try (Stream<String> lines = Files.lines(Paths.get(trainingPath))) {
+            lines.forEach(line -> {
+                if (line.trim().isEmpty()) {
+                    return;
+                }
+                String[] fields = line.split("\\s+");
+                if (fields.length < 8) {
+                    return;
+                }
+                String lemma = fields[6];
+                String roleset = fields[7];
+                if (lemma.equals("-") || roleset.equals("-")) {
+                    return;
+                }
+                String rolesetId = lemma + "." + roleset;
+                Map<String, Integer> counts = rolesetCounts.computeIfAbsent(lemma, l -> new HashMap<>());
+                counts.put(rolesetId, counts.getOrDefault(rolesetId, 0) + 1);
+            });
+        }
+        return rolesetCounts;
+    }
+
+    /**
+     * Write a JSON file with most frequent senses for VerbNet classes from a SemLink file.
+     * <p/>
+     * <code>
+     * {
+     * "recline": {
+     * "47.6": 3
+     * },
+     * "prepare": {
+     * "55.5-1": 37,
+     * "26.3-1": 40
+     * },
+     * ...
+     * </code>
+     *
+     * @param trainingPath CoNLL SRL input path
+     * @return VN class frequencies by lemma
+     */
+    public static Map<String, Map<String, Integer>> vnMostFrequent(String trainingPath) throws IOException {
+        Map<String, Map<String, Integer>> senseCounts = new HashMap<>();
+        try (Stream<String> lines = Files.lines(Paths.get(trainingPath))) {
+            lines.forEach(line -> {
+                if (line.trim().isEmpty()) {
+                    return;
+                }
+                String[] fields = line.split("\\s+");
+                if (fields.length < 5) {
+                    return;
+                }
+                String lemma = fields[3];
+                String sense = fields[4];
+                if (sense.equals("None")) {
+                    return;
+                }
+                Map<String, Integer> counts = senseCounts.computeIfAbsent(lemma, l -> new HashMap<>());
+                counts.put(sense, counts.getOrDefault(sense, 0) + 1);
+            });
+        }
+        return senseCounts;
+    }
+
+    public static void main(String[] args) throws IOException {
+        String framesPath = args[0];
+        String pbTrainPath = args[1];
+        String vnTrainPath = args[2];
+        String outputPath = args[3];
+        Map<String, Map<String, Integer>> pbCounts = pbMostFrequent(pbTrainPath);
+        Map<String, Map<String, Integer>> vnCounts = vnMostFrequent(vnTrainPath);
+        List<Frameset> frames = deserializeFrames(new ByteArrayInputStream(Files.readAllBytes(Paths.get(framesPath))));
+
+        writeNominalPredicateMappings(pbCounts, vnCounts, frames, outputPath);
+
+    }
+
+}

--- a/semparse-core/src/main/java/io/github/semlink/semlink/VerbNetAligner.java
+++ b/semparse-core/src/main/java/io/github/semlink/semlink/VerbNetAligner.java
@@ -31,11 +31,10 @@ import java.util.stream.Collectors;
 
 import io.github.clearwsd.type.DepTree;
 import io.github.clearwsd.type.FeatureType;
-import io.github.semlink.verbnet.VnClass;
-import io.github.semlink.verbnet.VnFrame;
 import io.github.semlink.app.Span;
 import io.github.semlink.parser.DefaultVerbNetProp;
 import io.github.semlink.parser.Proposition;
+import io.github.semlink.parser.VerbNetProp;
 import io.github.semlink.propbank.DefaultPbIndex;
 import io.github.semlink.propbank.frames.PbRole;
 import io.github.semlink.propbank.frames.Roleset;
@@ -49,6 +48,8 @@ import io.github.semlink.semlink.aligner.RelAligner;
 import io.github.semlink.semlink.aligner.RoleMappingAligner;
 import io.github.semlink.semlink.aligner.SelResAligner;
 import io.github.semlink.semlink.aligner.SynResAligner;
+import io.github.semlink.verbnet.VnClass;
+import io.github.semlink.verbnet.VnFrame;
 import io.github.semlink.verbnet.type.NounPhrase;
 import io.github.semlink.verbnet.type.SyntacticFrame;
 import io.github.semlink.verbnet.type.ThematicRoleType;
@@ -81,19 +82,20 @@ public class VerbNetAligner {
         );
     }
 
-    public List<DefaultVerbNetProp> align(@NonNull DepTree parsed,
-                                          @NonNull List<Proposition<VnClass, PropBankArg>> props) {
-        List<String> tokens = parsed.stream().map(node -> (String) node.feature(FeatureType.Text)).collect(Collectors.toList());
-
+    public List<VerbNetProp> align(@NonNull DepTree parsed,
+                                   @NonNull List<Proposition<VnClass, PropBankArg>> props) {
         return props.stream()
                 .filter(prop -> null != prop.predicate())
-                .map(prop -> alignProp(prop, parsed).tokens(tokens))
+                .map(prop -> alignProp(prop, parsed))
                 .collect(Collectors.toList());
     }
 
-    private DefaultVerbNetProp alignProp(Proposition<VnClass, PropBankArg> prop, DepTree parsed) {
+    private VerbNetProp alignProp(Proposition<VnClass, PropBankArg> prop, DepTree parsed) {
+        List<String> tokens = parsed.stream().map(node -> (String) node.feature(FeatureType.Text)).collect(Collectors.toList());
+
         DefaultVerbNetProp vnProp = new DefaultVerbNetProp()
-                .proposition(SemlinkRole.convert(prop));
+                .proposition(SemlinkRole.convert(prop))
+                .tokens(tokens);
 
         align(prop, parsed).ifPresent(aligned -> {
             // get thematic role alignment

--- a/semparse-core/src/main/java/io/github/semlink/verbnet/semantics/ThematicRoleArgument.java
+++ b/semparse-core/src/main/java/io/github/semlink/verbnet/semantics/ThematicRoleArgument.java
@@ -44,9 +44,11 @@ public class ThematicRoleArgument<T> extends VariableSemanticArgument<T> {
             type = Optional.of(ThematicRoleType.NONE);
         }
         this.thematicRoleType = type.get();
+        this.implicit = value.startsWith("?");
     }
 
     private ThematicRoleType thematicRoleType;
+    private boolean implicit;
 
     @Override
     public String toString() {

--- a/semparse-core/src/main/java/io/github/semlink/verbnet/type/Preposition.java
+++ b/semparse-core/src/main/java/io/github/semlink/verbnet/type/Preposition.java
@@ -42,7 +42,10 @@ public class Preposition extends FramePhrase {
      * Return valid prepositions for this phrase.
      */
     public Set<PrepType> valid() {
-        Set<PrepType> types = prep.types().stream().map(PrepType::fromString).collect(Collectors.toSet());
+        Set<PrepType> types = prep.types().stream()
+                .filter(type -> !type.isEmpty())
+                .map(PrepType::fromString)
+                .collect(Collectors.toSet());
         if (types.contains(PrepType.TO)) {
             types.addAll(PrepType.to());
         }

--- a/semparse-core/src/main/java/io/github/semlink/verbnet/type/ThematicRoleType.java
+++ b/semparse-core/src/main/java/io/github/semlink/verbnet/type/ThematicRoleType.java
@@ -45,6 +45,7 @@ public enum ThematicRoleType {
     CO_PATIENT,
     CO_THEME,
     CO_TOPIC,
+    CO_LOCATION,
     CONTEXT,
     DESTINATION,
     DURATION,
@@ -118,6 +119,14 @@ public enum ThematicRoleType {
                 return Optional.of(TOPIC);
             } else if (themRole.equalsIgnoreCase("TOPIC_J")) {
                 return Optional.of(CO_TOPIC);
+            } else if (themRole.equalsIgnoreCase("THEME_I")) {
+                return Optional.of(THEME);
+            } else if (themRole.equalsIgnoreCase("THEME_J")) {
+                return Optional.of(CO_THEME);
+            } else if (themRole.equalsIgnoreCase("LOCATION_I")) {
+                return Optional.of(LOCATION);
+            } else if (themRole.equalsIgnoreCase("LOCATION_J")) {
+                return Optional.of(CO_LOCATION);
             }
             log.warn("Unrecognized thematic role type: {}", themRole);
         }

--- a/semparse-core/src/main/resources/mappings/nominal-mappings.tsv
+++ b/semparse-core/src/main/resources/mappings/nominal-mappings.tsv
@@ -1,1922 +1,1552 @@
-abbreviation	abbreviate	45.4
-abdication	abdicate	10.11
-abduction	abduct	10.5
-ablation	ablate	10.1
-abolition	abolish	10.1
-abrasion	abrade	45.4
-absolution	absolve	80-1
-abstention	abstain	69
-abstraction	abstract	10.1
-abuse	abuse	33
-acceleration	accelerate	45.4
-acceptance	accept	29.2-1-1 77.1 13.5.2
-acclaim	acclaim	33
-accommodation	accommodate	26.9
-accompaniment	accompany	51.7
-accumulation	accumulate	47.5.2 13.5.2
-accusation	accuse	81
-achievement	achieve	55.2
-aching	ache	40.8.2
-acknowledgment	acknowledge	37.10 29.9-1
-acquisition	acquire	13.5.2-1
-acquittal	acquit	80-1
-acting	act	29.6-1
-activating	activate	45.4
-activation	activate	45.4
-adaptation	adapt	26.9
-adaption	adapt	26.9
-addiction	addict	96
-addition	add	22.1-2 108
-addressing	address	25.3
-adhesion	adhere	22.5
-adjustment	adjust	26.9
-administration	administer	13.2-1-1
-admiration	admire	31.2
-admission	admit	37.10 29.5-2
-admission	admit	65
-admitting	admit	37.10 29.5-2
-admitting	admit	65
-admonition	admonish	37.9-1 58.1
-adoption	adopt	93 29.2 29.1
-advance	advance	45.6-1 102 51.1-2 45.4
-advertisement	advertise	35.2
-advertising	advertise	35.2
-advice	advise	37.9-1 37.2 37.7-1 58.1
-affiliation	affiliate	22.2-2
-affirmation	affirm	31.2 29.5-2 78-1-1
-affliction	afflict	31.1
-agglomeration	agglomerate	45.4
-aggravation	aggravate	31.1
-aggregation	aggregate	47.5.2
-aging	age	45.4
-agitation	agitate	31.1
-agreement	agree	36.1-1
-aid	aid	72-1
-aim	aim	intend-61.2 wish-62
-airing	air	45.4
-alert	alert	37.9
-alienation	alienate	31.1
-allegation	allege	37.7
-alleviation	alleviate	80
-alliance	ally	71
-allocation	allocate	13.3
-allotment	allot	13.3
-allowance	allow	13.3-1
-allowance	allow	64.3 64.1-1
-alteration	alter	26.6.1 45.4
-alternation	alternate	22.2-2-1 86.1
-amalgamation	amalgamate	22.1-1-1 22.2-1-1
-ambulation	ambulate	51.3.2
-amplification	amplify	37.12 45.4
-amusement	amuse	31.1
-analysis	analyze	34.1
-analyze	analyze	34.1
-animation	animate	45.4
-annexation	annex	10.5
-annihilation	annihilate	44 42.1
-annnunciation	announce	37.7-1 48.1.2
-annotation	annotate	25.1
-announcement	announce	37.7-1 48.1.2
-announcing	announce	37.7-1 48.1.2
-appeal	appeal	31.4-3
-appearance	appear	48.1.1
-application	apply	105.1
-appointment	appoint	29.1
-appraisal	appraise	54.4
-appreciation	appreciate	31.2
-approach	approach	51.1-1
-approach	approach	98
-appropriating	appropriate	13.5.2
-appropriation	appropriate	13.5.2
-approval	approve	33 31.3-6 64
-approximation	approximate	34.2 54.4
-argument	argue	37.6 36.4-1 36.1-1-1
-arrangement	arrange	26.1 55.5-1 9.1
-arrival	arrive	51.1
-articulation	articulate	37.7-1
-ascending	ascend	47.7 51.1-3
-ascension	ascend	47.7 51.1-3
-ascent	ascend	47.7 51.1-3
-asphyxiation	asphyxiate	42.2 40.7
-assassination	assassinate	42.1
-assault	assault	33
-assembly	assemble	26.1
-assembly	assemble	47.5.2
-assertion	assert	29.5
-assessment	assess	34.2 34.1 54.4
-assignment	assign	13.3
-assimilation	assimilate	14-2-1 26.9
-assistance	assist	72-1
-association	associate	amalgamate-22.2-2
-assumption	assume	93
-assurance	assure	99 37.13 37.9
-attack	attack	33
-attacking	attack	33
-attainment	attain	13.5.1
-attempt	attempt	61
-attenuation	attenuate	45.4
-audit	audit	34.1
-augmentation	augment	45.4
-average	average	108-3
-averaging	average	108-3
-awakening	wake	45.4
-award	award	13.3
-baking	bake	26.1 26.3-1 45.3
-banding	band	22.4 22.3-2
-banging	bang	18.4-1 18.1
-banging	bang	43.2
-banking	bank	9.10
-banning	ban	67
-bargain	bargain	36.1 89
-bargaining	bargain	36.1 89
-barter	barter	13.6
-bashing	bash	18.4-1 18.1
-basking	bask	31.3-5
-bath	bathe	9.8 41.1.1
-bathing	bathe	9.8 41.1.1
-battering	batter	18.1-1
-batting	bat	40.3.2
-battle	battle	36.3-2 36.4-1
-bearing	bear	31.2
-bearing	bear	86.2-1
-beating	beat	18.1-1
-bedding	bed	9.10
-bedwetting	bedwet	45.4
-beginning	begin	55.1-1
-beheading	behead	42.2
-being	be	109-1-1
-belching	belch	40.1.1
-belittling	belittle	33
-bend	bend	47.6 47.7 50 26.5 45.2
-bending	bend	47.6 47.7 50 26.5 45.2
-bequest	bequeath	13.3
-bet	bet	70 94 54.5
-betting	bet	70 94 54.5
-bias	bias	96
-bickering	bicker	36.4-1
-bifurcation	bifurcate	45.4
-biking	bike	11.5 51.4.1-1
-billing	bill	54.5
-binding	bind	9.8 22.3-2-1
-bite	bite	40.8.3-2 18.2
-biting	bite	40.8.3-2 18.2
-blame	blame	33
-blanking	blanking	10.4.1
-blast	blast	43.2
-blaze	blaze	43.1
-bleeding	bleed	40.1.2 43.4-1
-blessing	bless	33
-blistering	blister	45.5
-blitz	blitz	44
-block	block	67 9.8 16
-blockade	blockade	9.8
-blockage	block	67 9.8 16
-blocking	block	67 9.8 16
-bloom	bloom	45.5 47.2
-blooming	bloom	45.5 47.2
-blossoming	blossom	47.2
-blow	blow	23.2
-blowing	blow	23.2
-blowing	blow	26.1
-blowing_up	blow_up	23.2
-blunting	blunt	45.4
-blurring	blur	45.4
-boarding	board	46
-boast	boast	37.8
-boating	boat	51.4.1
-boil	boil	26.3-2 45.3
-bombardment	bombard	9.8
-bond	bond	shake-22.3-2-1 tape-22.4
-bonding	bond	shake-22.3-2-1 tape-22.4
-boost	boost	102
-borrowing	borrow	13.5.2
-botching	botch	45.4
-bounce	bounce	51.3.2-2 11.2-1 51.3.1
-bow	bow	40.3.3 95
-bow	bow	47.3 47.6 50
-bowling	bowl	51.3.2-2
-boxing	box	9.10
-boxing	box	36.3-2
-boycott	boycott	52
-brawl	brawl	36.4-1
-brawling	brawl	36.4-1
-break	break	23.2 40.8.3-1-1 45.1
-break	break	48.1.1
-break_up	break_up	45.1
-breakdown	break_down	45.1
-breaking	break	23.2 40.8.3-1-1 45.1
-breaking_off	break_off	23.2
-breakup	break_up	45.1
-breastfeeding	breastfeed	39.7
-breath	breathe	40.1.2-1
-breathing	breathe	40.1.2-1
-briefing	brief	37.9
-broadcast	broadcast	37.4
-broadening	broaden	45.4
-bruising	bruise	40.8.3-2 21.2-1
-brushing	brush	41.2.1 41.2.2 10.4.2-1
-budding	bud	45.5
-build	build	26.1-1
-building	build	26.1-1
-bulging	bulge	47.5.3 47.2
-bullying	bully	59-1 29.8-1
-burden	burden	13.4.2-1-1
-burial	bury	9.1-1
-burn	burn	45.5 40.8.3-2 43.1 45.4
-burning	burn	45.5 40.8.3-2 43.1 45.4
-burping	burp	40.1.1
-burst	burst	45.4
-burst	burst	48.1.1
-buying	buy	13.5.1
-buyout	buy_out	13.5.1
-calcification	calcify	45.4
-calcifying	calcify	45.4
-call	call	13.5.1
-call	call	37.3
-call	call	60
-calling	call	13.5.1
-calling	call	29.3
-calling	call	37.3
-calling	call	60
-calving	calve	28
-camping	camp	46
-cancerization	cancerize	45.4
-canning	can	10.10
-cap	cap	9.9
-capitulation	capitulate	95
-capture	capture	10.5-1
-care	care	31.3
-caring	care	31.3
-cascading	cascade	47.7
-cast	cast	17.1
-casting	cast	26.1
-castration	castrate	45.4
-catalog	catalogue	29.10
-catalogue	catalogue	29.10
-catch	catch	13.5.1
-catching	catch	13.5.1
-categorization	categorize	29.10 45.4
-causation	cause	27.1-1, 27.2
-caution	caution	37.9-1
-celebration	celebrate	33
-certification	certify	29.2
-cessation	cease	55.4-1
-championing	champion	29.8-1
-championship	champion	29.8-1
-chance	chance	94-1
-change	change	26.6.1-1 45.4
-changing	change	26.6.1-1 45.4
-characterization	characterize	29.2-1
-charge	charge	51.3.2
-charge	charge	54.5
-chase	chase	51.6
-chasing	chase	51.6
-chat	chat	37.6
-chatting	chat	37.6
-cheating	cheat	10.6
-check	check	35.2
-check_up	check_up	35.2
-checking	check	35.2
-chemoprevention	chemoprevent	67
-chewing	chew	39.2-1
-chlorination	chlorinate	45.4
-choice	choose	13.5.1
-choking	choke	40.7
-choosing	choose	13.5.1
-chop	chop	21.2-2 21.1-1 18.2
-christening	christen	29.3
-circularisation	circularize	13.2-1-1
-circumcision	circumcise	45.4
-civilization	civilize	45.4
-claim	claim	37.7-1
-clapping	clap	40.3.1-1 43.2
-clarification	clarify	45.4
-clash	clash	18.4-1 43.2
-clash	clash	36.4-1
-classification	classify	29.2 29.10
-cleaning	clean	10.3 26.3-2 45.4
-cleaning	clean_up	10.3 26.3-2 45.4
-cleansing	cleanse	10.6
-clearance	clear	80-1 26.3-1 10.3-1 45.4
-clearing	clear	80-1 26.3-1 10.3-1 45.4
-cleavage	cleave	21.2-1
-clenching	clench	40.3.2
-click	click	40.3.2 43.2 18.1
-climb	climb	47.7-1, 45.6.1-1
-climb	climb	51.3.2, 51.1-1-3
-climbing	climb	47.7-1, 45.6.1-1
-climbing	climb	51.3.2, 51.1-1-3
-clip	clip	41.2.2 21.1-1
-clogging	clog	9.8 45.4
-close	close	40.3.2 45.4
-closing	close	40.3.2 45.4
-closing	close	45.4
-clothing	clothe	41.1.1
-clouding	cloud	45.4
-clubbing	club	18.3
-clubbing	clubbing	47.3 26.7
-clunking	clunk	43.2
-co-existence	coexist	36.1 47.1-1
-coagulation	coagulate	45.4
-coating	coat	9.8
-coblation	ablate	10.1
-coding	code	29.10
-coercion	coerce	59
-coexistence	coexist	36.1 47.1-1
-cohesion	cohere	89
-collaborating	collaborate	36.1 73-1 71
-collaboration	collaborate	36.1 73-1 71
-collapse	collapse	45.4
-collecting	collect	22.3-2 47.5.2 13.5.2 26.5 45.4
-collection	collect	22.3-2 47.5.2 13.5.2 26.5 45.4
-collision	collide	36.1 18.4-1 18.4
-collusion	collude	71
-coloration	color	24
-coloring	color	24
-combat	combat	36.4-1
-combination	combine	22.1-1-1
-combustion	combust	45.4
-coming	come	51.1
-commendation	commend	33
-comment	comment	37.11-1-1
-commentary	comment	37.11-1-1
-commercialization	commercialize	45.4
-commissioning	commission	59
-commitment	commit	79 92-1
-communicating	communicate	36.1 36.4-1 37.1.1
-communication	communicate	36.1 36.4-1 37.1.1
-comparison	compare	22.2-2
-compensation	compensate	33 13.4.2-1-1
-competition	compete	36.4-1
-compilation	compile	26.1
-complaining	complain	37.8
-complaint	complain	37.8
-completion	complete	55.2
-composition	compose	26.4
-composition	compose	26.7-2 26.4
-comprehension	comprehend	87.2-1
-compression	compress	26.5
-compromise	compromise	36.1
-compulsion	compel	59
-computation	compute	26.4
-con	con	59-1 10.6-1
-concentration	concentrate	focus-87.1
-concern	concern	31.1
-concession	concede	13.3
-conclusion	conclude	55.4-1
-conclusion	conclude	97.2
-condemnation	condemn	33 81
-condensation	condense	45.4
-conditioning	condition	41.2.2
-conduct	conduct	51.7
-confederation	confederate	22.2-2
-conference	confer	36.1 37.6
-confession	confess	37.10 37.7-1
-confirmation	confirm	29.5-2 78-1-1
-confiscation	confiscate	10.5
-conflict	conflict	36.4-1
-confrontation	confront	98
-confusion	confuse	amalgamate-22.2-2 amuse-31.1
-conglomeration	combine	22.1-1-1
-congratulation	congratulate	33
-congregation	congregate	47.5.2
-conization	conization	10.1
-connecting	connect	22.4 22.1-2-1
-connection	connect	22.4 22.1-2-1
-conquering	conquer	42.3
-conquest	conquer	42.3
-conservation	conserve	13.5.1
-consideration	consider	29.9-1-1-1
-consolation	console	31.1
-consolidation	consolidate	22.2-2-1 22.2-1-1 22.1-1
-conspiracy	conspire	71
-constitution	constitute	55.5
-construction	construct	26.4 45.4
-consult	consult	37.1.2 36.3-1 36.4
-consultation	consult	37.1.2 36.3-1 36.4
-consulting	consult	37.1.2 36.3-1 36.4
-consuming	consume	39.4-1 66
-consumption	consume	39.4-1 66
-containment	contain	47.8 54.3
-contamination	contaminate	9.8
-content	content	31.1
-contention	contend	36.4
-continuation	continue	55.6 55.3
-contracting	contract	45.4
-contracting	contract	89 13.5.3
-contraction	contract	45.4
-contrast	contrast	22.2-2-1
-contribution	contribute	13.2-1-1
-convening	convene	47.5.2
-convention	convene	47.5.2
-convergence	converge	47.7 87.1
-conversation	converse	37.6
-conversion	convert	26.6.1-1 26.6.2-1
-conveyancing	conveyancing	11.1
-convulsion	convulse	40.6
-cooking	cook	26.1 26.3-1 45.3
-cooling	cool	45.4
-cooperation	cooperate	36.1 73-1
-coping	cope	83-1
-copy	copy	25.2 25.4
-copying	copy	25.2 25.4
-correction	correct	45.4
-correlation	correlate	22.2-2-1 86.1
-corrosion	corrode	45.5 45.4
-corruption	corrupt	45.4
-cost	cost	54.2
-cough	cough	40.1.2-1
-coughing	cough	40.1.2-1
-counseling	counsel	37.9-1
-count	count	34.2 108
-counting	count	34.2 108
-coupling	couple	22.2-1
-coverage	coverage	9.8 47.8
-covering	cover	9.8 47.8
-crabbing	crab	13.7
-crack	crack	43.2
-crack	crack	61
-cracking	crack	18.4-1 18.3
-cracking	crack	43.2
-cracking	crack	45.1
-crash	crash	18.4-1 43.2 45.1
-craving	crave	32.1 32.2-1
-creation	create	26.4, 27.1
-credit	credit	13.4.1-1
-crepitation	crepitate	43.2
-criticism	criticize	33
-criticizing	criticize	33
-crossing	cross	47.8-1, 40.3.2
-crossing	cross	51.1-1-3, 47.7
-crossing_out	cross_out	40.3.2
-crushing	crush	31.1 42.3 45.1 21.2-1
-crusting	crust	45.5
-cry	cry	37.3
-crying	cry	31.3-3 40.1.2-1 40.2 43.2
-crying	cry	37.3
-crying_out	cry_out	37.3
-cuddling	cuddle	36.2
-cultivation	cultivate	26.3-1
-curb	curb	42.3
-cure	cure	10.6 80-1
-cut	cut	31.1 41.2.2 26.1-1 21.1-1 40.8.3-2 47.7 23.2
-cutting	cut	31.1 41.2.2 26.1-1 21.1-1 40.8.3-2 47.7 23.2
-cycling	cycle	51.4.1-1
-damage	damage	44
-dampening	dampen	42.3
-dampening	dampen	45.4
-dance	dance	26.7-1-1 51.5
-dance	dance	47.3
-dancing	dance	26.7-1-1 51.5
-darkening	darken	45.4
-dating	date	25.3
-dating	date	36.2
-dawn	dawn	48.1.1
-dazzling	dazzle	31.1
-deal	deal	13.1
-deal	deal	83
-dealing	deal	13.1
-dealing	deal	83
-death	die	48.2
-debate	debate	37.6 36.3-2 36.1-1-1
-debriefing	debrief	37.9
-deceleration	decelerate	45.4
-deception	deceive	59-1
-decision	decide	13.5.1
-declaration	declare	37.7-1 48.1.2
-decline	decline	45.6-1
-decomposition	decompose	45.5
-decompression	decompress	45.4
-deconditioning	decondition	41.2.2
-decoration	decorate	9.8 25.3
-decrease	decrease	45.6-1 45.4
-dedication	dedicate	79
-deduction	deduct	10.1 108-2
-deepening	deepen	45.4
-defamation	defame	33
-defecation	defecate	40.1.2-1
-defence	defend	85
-defense	defend	85
-definition	define	29.2-1-1 48.1.2
-deflation	deflate	45.4
-deforestation	deforest	10.8
-deformation	deform	26.6.1
-degeneration	degenerate	45.4
-degradation	degrade	45.4
-dehydration	dehydrate	45.4
-delay	delay	53.1-1
-deleting	delete	10.1
-deletion	delete	10.1
-deliberation	deliberate	36.1 36.3-1
-delivery	deliver	11.1
-delusion	delude	59-1
-demand	demand	103 60-1
-demolition	demolish	44 31.1
-demonstration	demonstrate	37.1.1 78-1-1
-demoralization	demoralize	31.1
-dent	dent	21.2-1
-denunciation	denounce	33
-departure	depart	10.11 51.1-1
-dependency	depend	70
-depiction	depict	29.2
-depletion	deplete	10.6
-deportation	deport	10.2
-deposit	deposit	9.1-1
-deposition	deposit	9.1-1
-depreciation	depreciate	45.6-1
-depression	depress	31.1
-deprivation	deprive	10.6
-derision	deride	33
-derivation	derive	97.2 48.1.1 26.4
-desalination	desalinate	45.4
-desalinization	desalinate	45.4
-desaturation	desaturate.	45.4
-descending	descend	47.7 51.1-3
-description	describe	29.2-1-1
-desecration	desecrate	44
-design	design	26.4-1
-designation	designate	29.1
-desire	desire	32.1
-destabilization	destabilize	45.4
-destruction	destroy	44
-detachment	detach	23.3
-detection	detect	30.1-1
-deterioration	deteriorate	45.5 45.4
-determination	determine	29.5-1 84
-devaluation	devalue	45.4
-devastation	devastate	44 31.1
-development	develop	26.1 26.2
-development	develop	48.3 48.1.1
-deviation	deviate	23.4
-devolution	devolve	13.3
-devotion	devote	79
-deworming	deworm	10.8
-diagnosis	diagnose	29.2
-dictating	dictate	37.1.1-1
-dictation	dictate	37.1.1-1
-die	die	48.2
-differentiation	differentiate	23.1-1
-diffraction	diffract	45.4
-diffusion	diffuse	45.4
-dig	dig	35.1
-digging	dig	35.1
-diminution	diminish	45.6-1 45.4
-dining	dine	39.5
-directing	direct	26.7-1
-direction	direct	26.7-1
-disagreement	disagree	36.1 36.4-1
-disappointment	disappoint	31.1
-disarmament	disarm	10.6 31.1
-disarming	disarm	10.6 31.1
-disclosure	disclose	37.7 78-1-1
-discontinuation	discontinue	55.2
-discovery	discover	30.2 29.5-2 84
-disgust	disgust	31.1
-dishonor	dishonor	31.1
-dishonour	dishonor	31.1
-disintegration	disintegrate	45.4
-dislocation	dislocate	45.4
-disorganization	disorganize	45.4
-display	display	48.1.2
-dispute	dispute	36.4-1
-dissatisfaction	dissatisfy	31.1
-dissemination	disseminate	13.2-1
-dissent	dissent	36.1
-dissention	dissent	36.1
-dissipation	dissipate	45.4
-dissociation	dissociate	23.1-2
-dissolution	dissolve	45.4
-distension	distend	45.2
-distention	distend	45.2
-distortion	distort	26.5
-distraction	distract	31.1
-distribution	distribute	13.2-1
-disturbance	disturb	31.1
-divergence	diverge	23.4
-diversification	diversify	45.4
-diversion	divert	31.1
-dividing	divide	23.1-1 45.4
-dividing	divide	108-1
-diving	dive	35.2
-division	divide	23.1-1 45.4
-divorce	divorce	36.2
-dock	dock	9.10-1
-docking	dock	9.10-1
-dockings	dock	9.10-1
-documentation	document	25.4
-dogsledding	dogsled	51.4.1
-dominance	dominate	47.8-2
-domination	dominate	47.8-2
-dominion	dominate	47.8-2
-donation	donate	13.2-1-1
-doubling	double	45.4
-doubt	doubt	33 29.5-1
-douching	douche	41.2.1 41.1.1
-drafting	draft	26.4
-drag	drag	11.4 35.2
-draining	drain	10.6-1 10.3-1 45.4
-draw	draw	11.4 23.2 10.1
-draw_down	draw	11.4 23.2 10.1
-drawing	draw	11.4 23.2 10.1
-drawing	draw	26.7-2-1 25.2
-dream	dream	62
-dreaming	dream	62
-dredging	dredge	35.2
-dressing	dress	41.1.1
-dribbling	dribble	40.1.2
-drilling	drill	21.2-2
-drink	drink	39.1-2
-drinking	drink	39.1-2
-drive	drive	11.5
-drive_around	drive	11.5
-driving	drive	11.5
-drooling	drool	40.1.2 43.4
-drooping	droop	47.6
-drop	drop	9.4 45.6-1 51.3.1 47.7
-drop	drop	10.10
-dropping	drop	9.4 45.6-1 51.3.1 47.7
-dropping	drop	10.10
-dueling	duel	36.4-1
-dumping	dump	9.3-1-1
-duplication	duplicate	25.4
-dusting	dust	9.7-2
-dying	die	48.2
-eating	eat	39.1-1
-echo	echo	47.4
-edification	edify	45.7
-educating	educate	37.9
-education	educate	37.9
-effect	affect	31.1
-effort	effort	try-61
-ejection	eject	10.1
-elaboration	elaborate	37.11-1-1
-election	elect	29.1
-electrocoagulation	coagulate	45.4
-electrodesiccation	desiccate	45.4
-elevation	elevate	9.4
-elimination	eliminate	10.1
-emancipation	emancipate	10.5
-embrace	embrace	36.2
-employment	employ	13.5.3
-employment	employ	105.1
-emptying	empty	45.4 10.3-1
-encouragement	encourage	37.9 58.1-1-1
-encouragement	encourage	102 31.1 77.1
-end	end	55.4-1
-ending	end	55.4-1
-endowment	endow	9.8
-engagement	engage	31.1 22.2-3-2 107 13.5.3
-enrollment	enroll	107
-enrolment	enroll	107
-entering	enter	51.1-2
-entrance	enter	51.1-2
-entry	enter	51.1-2
-eradication	eradicate	10.1
-erection	erect	26.1
-erosion	erode	45.5
-eruption	erupt	48.1.1
-escape	escape	51.1-1
-establishment	establish	55.5-1 97.1 78-1-1
-estimate	estimate	54.4
-estimation	estimate	54.4
-evacuation	evacuate	10.2
-evaluation	evaluate	34.1
-evaporation	evaporate	45.4
-evasion	evade	52
-evening_out	even_out	45.4
-evolution	evolve	48.1.1, 26.2.1
-exaction	exact	13.5.2
-exam	examination	35.4
-examination	examination	35.4
-examination	examine	30.2 35.4
-excavation	excavate	35.2
-exchange	exchange	13.6-1
-excision	excise	10.1
-excitement	excite	31.1
-exclusion	exclude	65
-exclusive	exclude	65
-excommunication	excommunicate	10.1
-excoriation	excoriate	33
-execution	execute	42.1
-exenteration	exenterate	42.2 10.8
-exercise	exercise	26.8
-exercise	exercise	41.1.1
-exertion	exert	105
-exhaustion	exhaust	31.1
-exhibition	exhibit	48.1.2
-exile	exile	36.4
-existing	exist	47.1-1 39.6
-exit	exit	51.1-1
-expansion	expand	45.4
-expectation	expect	29.5-1 62
-experience	experience	30.2
-expiration	expire	40.1.3
-expiration	expire	48.2
-explanation	explain	37.1.1 78-1
-exploitation	exploit	105
-exploiting	exploit	105
-explosion	explode	43.2 45.4
-explosion	explode	45.6-1
-exposure	expose	78 48.1.2
-expression	express	48.1.2
-expulsion	expel	10.2 10.1
-extension	extend	13.3 13.2-2
-extension	extend	47.1-1
-extermination	exterminate	44
-extortion	extort	10.5
-extracting	extract	10.1
-extraction	extract	10.1
-extradition	extradite	10.2
-extrapolating	extrapolate	108-2
-extrapolation	extrapolate	108-2
-extrusion	extrude	10.1
-fabrication	fabricate	26.4
-failing	fail	neglect-75.1-1 succeed-74-3-1-1
-failure	fail	neglect-75.1-1 succeed-74-3-1-1
-fainting	faint	40.8.4
-fall	fall	45.6-1 51.1
-falling	fall	45.6-1 51.1
-fancy	fancy	31.2 32.1
-farting	fart	40.1.1
-fascination	fascinate	31.1
-fault	fault	33
-favor	favor	31.2
-favour	favor	31.2
-fax	fax	37.4
-fear	fear	31.3, 31.2-1
-federation	federate	45.4
-feeding	feed	39.6 39.7
-feeling	feel	30.1-1-1, 30.3
-fermentation	ferment	45.5
-feud	feud	36.4-1
-feuding	feud	36.4-1
-fibrillation	fibrillate	45.4
-fight	fight	36.3-2 36.4-1
-fighting	fight	36.3-2 36.4-1
-file	file	9.10
-filing	file	9.10
-filling	fill	9.8 47.8 45.4
-filming	film	25.4
-filtration	filter	10.4.2
-find	find	84 13.5.1
-finding	find	84 13.5.1
-fine	fine	54.5
-fire	fire	17.1-1
-firing	fire	10.10
-fishing	fish	35.1 13.7
-fissuring	fissure.	45.1
-fit	fit	26.9 9.3-1 54.3
-fitting	fit	26.9 9.3-1 54.3
-fix	fix	22.3-2 54.4
-fixation	fixate	87.1 22.3-2-1
-flaking	flake	21.2-1
-flash	flash	40.3.2 43.1
-flashing	flash	40.3.2 43.1
-flattening	flatten	21.2-1 45.4
-fleeing	flee	51.1-1
-flexion	flex	40.3.2
-flickering	flicker	43.1
-flight	flee	51.1-1
-flight	fly	51.3.2-2-1 11.5-1 51.4.2
-flipping	flip	17.1-1
-floating	float	47.3 51.3.2-2 11.2-1 51.3.1
-flood	flood	9.8 45.4
-flooding	flood	9.8 45.4
-flossing	floss	41.2.1
-flotation	float	47.3 51.3.2-2 11.2-1 51.3.1
-flow	flow	47.2
-fluctuation	fluctuate	45.6-1
-flushing	flush	10.4.1
-flushing	flush	40.1.1
-fluttering	flutter	47.3 40.3.2
-flying	fly	51.3.2-2-1 11.5-1 51.4.2
-foaming	foam	43.4 47.2
-following	follow	87.2-1 51.6
-forgiving	forgive	33
-formation	form	48.1.1 26.4 48.1.2
-formatting	format	55.5-1
-forming	form	48.1.1 26.4 48.1.2
-formulation	formulate	26.1 26.4
-forwarding	forward	11.1-1
-foundation	found	55.5-1 97.1
-founding	found	55.5-1 97.1
-freeing	free	80-1
-freeze	freeze	57 45.4
-freezing	freeze	57 45.4
-fright	frighten	31.1
-frost	frost	45.4
-frustration	frustrate	31.1
-function	function	29.6
-functioning	function	29.6
-fusion	fuse	22.1-1-1 22.3-1-1
-gain	gain	13.5.1-1
-gain	gain	45.6-1
-gamble	gamble	70 94
-gambling	gamble	70 94
-gathering	gather	22.3-2 47.5.2 13.5.1
-gauge	gauge	34.2 54.4
-generating	generate	27 26.2
-generation	generate	27 26.2
-germination	germinate	45.5
-gesture	gesture	40.3.1
-giving	give	13.1-1
-glare	glare	30.3 40.2
-glimpse	glimpse	30.2
-going	go	51.1
-gossiping	gossip	37.6
-gouging	gouge	21.2-1
-grabbing	grab	15.1, 13.5.2, 10.5-1
-grading	grade	29.10
-grading	grade	45.4
-grafting	graft	22.3-2-1
-grant	grant	13.3 29.5-2
-granting	grant	13.3 29.5-2
-granulation	granulate	45.4
-grasp	grasp	20-1 15.1-1 87.2-1
-greeting	greet	33
-grievance	complain	37.8
-grinding	grind	26.1 40.3.2 21.2-1
-grip	grip	20-1 15.1-1
-groan	groan	37.3 40.2
-groaning	groan	37.3 40.2
-grooming	groom	41.1.2
-grooving	groove	9.9
-grouping	group	22.3-2 47.5.2 29.10
-growing	grow	26.1 26.2.1
-growing	grow	45.6-1-1 45.4
-growing	grow	48.1.1
-growing_up	grow_up	26.2
-grumble	grumble	37.3 37.8
-guarantee	guarantee	13.3 99 37.13 29.5-2
-guarding	guard	29.8-1
-guess	guess	29.5-1
-guidance	guide	59-1 51.7
-gushing	gush	31.3-8
-gushing	gush	48.1.1 43.4
-gutting	gut	10.7
-hacking	hack	23.2
-hacking	hack	26.1 21.1-1
-hacking_away	hack_away	26.1 23.2 21.1-1
-hallucination	hallucinate	31.3-8
-halt	halt	55.4 45.4
-hammering	hammer	18.1-1 18.4-1
-hand-delivery	handdeliver	11.1
-handdelivery	handdeliver	11.1
-handle	handle	15.1 98
-handling	handle	15.1 98
-handwritting	handwrite	26.7-2-1 25.2 37.1.1-1-1 37.7 37.11-1
-hanging	hang	40.3.2 47.6 9.2-1 42.2 9.7-1
-hanging	hang	47.6 50
-hankering	hanker	32.2-1
-happening	happen	48.3
-happiness	happy	31.1
-harassment	harass	31.1
-hardening	harden	45.4
-harm	harm	31.1
-harming	harm	31.1
-hating	hate	31.2-1
-hatred	hate	31.2-1
-hauling	haul	11.4
-healing	heal	45.4
-hearing	hear	30.1-1-1 84-1-1
-heating	heat	45.3 45.4
-heightening	heighten	45.4
-help	help	72-1
-hemorrhaging	hemorrhage	40.1.3
-herding	herd	47.5.2
-hesitation	hesitate	53.1
-hiding	hide	16-1
-highjacking	hijack	59-1
-highlighting	highlight	41.2.2
-hijacking	hijack	59-1
-hiking	hike	51.3.2
-hint	hint	37.7-2
-hire	hire	13.5.1 13.5.3
-hiring	hire	13.5.1 13.5.3
-hissing	hiss	37.3
-hit	hit	18.1-1 17.1-1 47.8-1 18.4 40.8.3
-hit	hit	42.1
-hitting	hit	18.1-1 17.1-1 47.8-1 18.4 40.8.3
-hold	hold	15.1 49.2 15.2 100.1 15.3
-holding	hold	15.1 49.2 15.2 100.1 15.3
-holding	hold	29.5-1
-holding	hold	54.3
-holding	hold	55.6
-holding_on	hold_on	15.1-1
-holiday	holiday	56
-holidaying	holiday	56
-hopping	hop	47.5.1-1 51.3.2-1
-hosting	host	29.8-1
-housing	house	54.3 9.10
-humidification	humidify	45.4
-humiliation	humiliate	31.1
-hunting	hunt	35.1
-hurry	hurry	51.3.2-2 53.2
-hurting	hurt	31.1, 31.3, 40.8.1
-hurting	hurt	40.8.3-2 31.1
-hybridization	hybridize	45.4
-hydration	hydrate	45.4
-hyperextension	hyperextend	45.2
-hyperventilating	hyperventilate	47.5.3
-hyperventilation	hyperventilate	47.5.3
-hypoventilation	hypoventilate	40.1.2
-identification	identify	29.2-1-1
-identification	identify	88.2
-illumination	illuminate	25.3
-illustration	illustrate	25.3
-imagination	imagine	29.2-1-1 29.9-1-1-1
-imitation	imitate	101
-immersion	immerse	9.1
-impediment	impede	67
-implantation	implant	9.1
-implementation	implement	55.5-1
-imposition	impose	63
-improvement	improve	45.4
-incision	incise	25.1
-incitement	incite	59
-inclusion	include	107 65
-incorporation	incorporate	22.2-1
-increase	increase	45.6-1 45.4
-incrimination	incriminate	33
-incubation	incubate	45.4
-indication	indicate	78-1
-indictment	indict	33
-induction	induce	27
-induration	indurate	45.4
-infection	infect	9.8
-inference	infer	97.2 29.5-1
-infestation	infest	9.8
-inflammation	inflame	31.1
-inflation	inflate	45.4
-influence	influence	59-1
-ingestion	ingest	39.4-1
-inhalation	inhale	40.1.3-2
-inheritance	inherit	13.5.2
-inhibition	inhibit	67
-initiation	initiate	55.5-1
-injection	inject	9.8
-injury	injure	40.8.3-2
-innovation	innovate	55.5
-input	input	9.1
-input	input	37.11
-inquiry	inquire	37.1.2
-inscription	inscribe	25.1
-insertion	insert	9.1-1
-insistence	insist	37.7
-inspection	inspect	30.2 35.4
-inspiration	inspire	27.1-1, 31.1
-installation	install	9.1-1 29.1
-installment	install	9.1-1 29.1
-institution	institute	55.5-1
-instruction	instruct	37.9
-insulation	insulate	9.9
-insult	insult	33.1-1, 31.1
-integration	integrate	22.2
-intensification	intensify	45.4
-intent	intend	61.1 61.2-1-1 62
-intention	intend	61.1 61.2-1-1 62
-interaction	interact	36.1
-interception	intercept	98
-interest	interest	31.1
-interesting	interest	31.1
-interpolation	interpolate	108-2
-interpretation	interpret	29.2
-interpreting	interpret	29.2
-interrogation	interrogate	37.1.3
-intersection	intersect	47.8-1
-interspersing	intersperse	9.8 22.2-2-1
-interview	interview	37.1.3
-intimidation	intimidate	31.1
-intonation	intone	26.7-1
-intoxication	intoxicate	31.1
-introduction	introduce	22.2-3-1 55.5-1
-intrusion	intrude	48.1.2
-inundation	inundate	9.8
-invagination	invaginate	45.4
-invention	invent	26.4 26.3-1
-inversion	invert	45.4
-investigation	investigate	30.2 35.4
-investment	invest	13.4.2
-invitation	invite	102 60
-involvement	involve	103 107 86.2-1
-irritation	irritate	31.1
-isolation	isolate	16 29.10
-issuance	issue	13.3 13.4.1 48.1.1
-issue	issue	13.3 13.4.1 48.1.1
-itching	itch	40.8.1
-jab	jab	18.1-1
-jeering	jeer	40.2
-jogging	jog	51.3.2-2-1
-joining	join	22.1-2-1
-joining_up	join_up	22.1-2-1
-joke	joke	37.6
-jolt	jolt	31.1
-journey	journey	51.3.2-1
-judgement	judge	34.2 29.4-1-1-2 29.2
-judgment	judge	34.2 29.4-1-1-2 29.2
-jump	jump	45.6-1
-jump	jump	51.3.2
-jumping	jump	51.3.2
-justification	justify	37.1.1
-kayaking	kayak	51.4.1-1
-keeping	keep	55.6
-keeping	keep	55.6 15.2
-keeping_up	keep_up	55.6
-keratinization	keratinize	45.4
-kick	kick	23.2 40.3.2 49 11.4-1-1 18.1-1 17.1-1-1 18.2
-kicking	kick	23.2 40.3.2 49 11.4-1-1 18.1-1 17.1-1-1 18.2
-kidnapping	kidnap	10.5
-kill	kill	42.1-1 42.3
-killing	kill	42.1-1 42.3
-killing	kill	74
-kiss	kiss	36.2 20-1
-kissing	kiss	36.2 20-1
-kneading	knead	26.5
-knifing	knife	42.2 18.3
-knitting	knit	26.1
-knock	knock	18.1-1 17.1-1 18.4-1
-knowledge	know	comprehend-87.2-1 conjecture-29.5-1 consider-29.9-1-1
-labeling	label	9.9 29.3 25.3
-landing	land	9.10-1
-laugh	laugh	40.2
-laughing	laugh	40.2
-launch	launch	17.1-1-1 55.5-1
-laying	lay	9.2
-lead	lead	51.7
-lead	lead	59.1, 27.2
-lead	lead	95.2.2
-leadership	lead	95.2.2
-leading	lead	51.7
-leading	lead	59.1, 27.2
-leading	lead	95.2.2
-leak	leak	43.4
-leakage	leak	43.4
-leaking	leak	43.4
-leap	leap	51.3.2-1
-leaping	leap	51.3.2-1
-learning	learn	14-1 84-1-1
-leasing	lease	13.1-1
-leasing	lease	13.5.1
-lending	lend	13.1
-lesson	lesson	37.1
-levitation	levitate	45.4
-liberation	liberate	10.5 80
-license	license	101
-licensing	license	101
-lifting	lift	9.4
-ligation	ligate	22.3-2-1
-liking	like	32.1-1-1 31.2-1
-limit	limit	76
-limitation	limit	76
-lining	line	9.8 47.8
-linkage	link	22.4 22.1-2-1
-liquidation	liquidate	42.1
-listening	listen	30.3 35.5
-living	live	47.1-1 46 39.6
-loading	load	9.7-2
-loan	loan	13.1
-lobbying	lobby	58.1
-locking	lock	22.4
-lodging	lodge	9.10-1 9.1
-lodging	lodge	46
-logging	log	13.7
-look	look	30.3 35.5
-look	look	30.4
-looking	look	30.3 35.5
-loosening	loosen	45.4
-loss	lose	13.2
-love	love	31.2-1
-lowering	lower	9.4
-lubrication	lubricate	9.9
-lurking	lurk	47.1-1
-maceration	macerate	45.4
-magnifying	magnify	45.4
-maintenance	maintain	55.6 29.5-2
-make	make	26.1-1
-make_up	make_up	26.1-1
-making	make	26.1-1
-manifestation	manifest	48.1.2
-manipulation	manipulate	59-1
-manufacturing	manufacture	26.4
-march	march	51.3.2-2-1
-marginalisation	marginalize	45.7
-marginalization	marginalize	45.7
-mark	mark	25.1
-marking	mark	25.1
-marriage	marry	36.2 22.2-3-1-1
-massacre	massacre	42.1
-massage	massage	20-1
-match	match	22.2-1
-matching	match	22.2-1
-maturation	maturate	26.2 45.4
-maturity	maturate	26.2 45.4
-measure	measure	54.1-1
-measurement	measure	54.1-1
-measuring	measure	54.1-1
-meditation	meditate	31.3-8
-meeting	meet	36.3-1
-memorization	memorize	14-2
-mentation	mentate	29.9 62
-mention	mention	37.7-1
-meowing	meow	38
-merger	merge	22.1-1-1
-merging	merge	22.1-1-1
-militarization	militarize	45.7
-milling	mill	21.2-2
-mining	mine	35.1 10.9
-misappropriation	misappropriate	10.5
-misdirection	misdirect	51.7
-misinterpretation	misinterpret	87.2
-misperception	misperceive	30.2 29.2
-missing	miss	31.2
-mistrust	mistrust	31.2
-misunderstanding	misunderstand	87.2
-mixing	mix	22.1-1-1 26.3-1
-moaning	moan	37.3 40.2
-mobilization	mobilize	45.4
-mobilizing	mobilize	45.4
-model	model	26.4
-modeling	model	26.4
-modeling	model	29.8
-moderation	moderate	45.4
-modernization	modernize	45.4
-modulation	modulate	45.4
-moisturization	moisturize	41.1.1
-monitoring	monitor	35.4
-mopping	mop	10.4.2-1
-moralizing	moralize	37.11-1
-motivation	motivate	59
-mourning	mourn	31.3, 31.2
-move	move	45.6 11.2 51.3.1
-movement	move	45.6 11.2 51.3.1
-moving	move	31.1
-moving	move	45.6 11.2 51.3.1
-mowing	mow	21.2-2
-muffling	muffle	42.3
-murder	murder	42.1
-murdering	murder	42.1
-mutation	mutate	26.6.1
-mutilation	mutilate	44
-muttering	mutter	37.3
-myelosuppression	myelosuppress	16 42.3
-naming	name	29.3
-nap	nap	40.4
-narration	narrate	37.1.1
-narrowing	narrow	45.4
-nationalization	nationalize	45.4
-navigation	navigate	51.4.2
-need	need	32.1-1-1 103
-neglect	neglect	75-1-1
-negotiating	negotiate	36.1
-negotiation	negotiate	36.1
-neighboring	neighbor	47.8
-networking	network	22.1
-nomination	nominate	29.1
-nonexisting	nonexistent	47.1-1
-normalization	normalize	45.4
-note	note	30.2
-notice	notice	25.2 37.11 37.7 37.1.1 26.7
-notice	notice	30.1-1
-noticing	notice	30.1-1
-notification	notify	37.2 37.9
-notifying	notify	37.2 37.9
-nudging	nudge	17.1-1
-nursing	nurse	29.8-1
-oath	oath	13.3 37.13
-objection	object	37.8
-obligation	obligate	59
-obliteration	obliterate	44
-observation	observe	30.2 35.4
-observation	observe	37.7-1 29.5-2
-obsession	obsess	31.1, 31.3
-obstructing	obstruct	67
-obstruction	obstruct	67
-occlusion	occlude	45.4
-occupation	occupy	31.1
-offense	offend	31.1
-offer	offer	13.3
-offering	offer	13.3
-omission	omit	10.1 75-1
-oozing	ooze	43.4
-opacification	opacify	45.4
-opening	open	47.6 40.3.2 45.4
-opening_up	open_up	45.4
-operating	operate	45.4
-operation	operate	45.4
-opposition	oppose	22.2-3
-order	order	9.1
-order	order	13.5.1
-order	order	60-1
-ordering	order	13.5.1
-ordering	order	60-1
-ordinance	ordain	29.1
-organization	organize	59-1 55.5-1 26.4
-organizing	organize	59-1 55.5-1 26.4
-ossification	ossify	45.4
-ousting	oust	10.1
-outfitting	outfit	41.3.3 13.4.2-1
-outrage	outrage	31.1
-overestimation	overestimate	54.4
-overlap	overlap	22.2-1
-overlapping	overlap	22.2-1
-overpayment	overpay	68
-ownership	own	100
-packaging	package	22.3-2-1
-packing	pack	9.7-1-1
-painting	paint	25.2 9.9
-painting	paint	26.7-2-1 24
-painting	paint	29.2
-pairing	pair	22.2-2 22.3-2 22.1-2-1
-palliation	palliate	80
-palpitation	palpitate	40.8.2
-pant	pant	40.1.1
-parade	parade	51.3.2
-paralysis	paralyze	45.4
-parching	parch	45.3
-pardon	pardon	33
-participation	participate	73-2
-partition	partition	23.3
-pass	pass	13.1 11.1-1 17.1-1
-passage	pass	48.3 47.7
-passing_on	pass_on	11.1
-patent	patent	101
-patrol	patrol	35.2
-pawn	pawn	13.1-1
-payment	pay	68-1
-perception	perceive	30.2
-percolation	percolate	43.4 45.3
-perfection	perfect	45.4
-perforation	perforate	21.2-1
-performance	perform	26.7-1
-permission	permit	64.3-1, 64.1-1
-persecution	persecute	33
-persistence	persist	47.1-1
-persuasion	persuade	59
-perturbation	perturb	31.1
-phoning	phone	13.5.1, 37.4.2-1, 37.4.1
-photo	photograph	25.4
-picketing	picket	35.4
-picking	pick	13.5.1
-piercing	pierce	19
-pioneering	pioneer	29.8-1
-pitch	pitch	17.1-1
-pitching	pitch	17.1-1
-pity	pity	31.2
-placement	place	9.1-2
-plan	plan	62
-planning	plan	62
-planting	plant	9.1-1 55.5-1 9.7-2
-plaquing	plaque	47.5.2 13.5.2
-play	play	26.7-1-1
-playing	play	26.7-1-1
-plot	plot	25.2 36.1
-plugging	plug_up	9.8
-plunge	plunge	45.6-1 47.7
-plunge	plunge	51.1
-poisoning	poison	42.2
-poking	poke	19 35.5
-polarization	polarize	45.4
-policing	police	29.8-1
-polish	polish	9.9 10.4.1
-pollution	pollute	9.8-1
-pooling	pool	22.1-2-1
-popping	pop	43.2
-popping	pop	45.4
-portrayal	portray	29.2-1-1
-posing	pose	29.6-2
-posing	pose	37.1.1
-positioning	position	9.1
-post	post	11.1
-posting	post	11.1
-pounding	pound	18.1-1
-pounding	pound	26.1
-pouring	pour	9.5 43.4
-praise	praise	29.2, 33.1-1-1
-preaching	preach	37.11-1 37.1.1
-precedence	precede	47.8
-preconception	preconceive	29.2-1 97.2
-prediction	predict	78
-preference	prefer	32.1-1-1 31.2
-pregnancy	impregnate	9.8
-preoccupation	preoccupy	31.1
-preparation	prepare	26.3-1
-preparation	prepare	55.5-1
-presentation	present	13.4.1 48.1.2
-presenting	present	13.4.1 48.1.2
-preservation	preserve	85
-pressing	press	59 12-1-1
-presumption	presume	29.5-1
-prevention	prevent	67
-price	price	54.4
-pricing	price	54.4
-printing	print	25.2
-proceeding	proceed	55.1
-procession	proceed	55.1
-procurement	procure	13.5.1
-producing	produce	26.7-2 26.4
-production	produce	26.7-2 26.4
-profession	profess	29.4-1-1-3
-progress	progress	45.5
-progression	progress	45.5
-prohibition	prohibit	67
-projection	project	34.2
-projection	project	47.6
-proliferation	proliferate	45.4
-promise	promise	13.3
-promotion	promote	102
-prompting	prompt	59
-pronunciation	pronounce	29.3
-proof	prove	97.2 29.4-1-1 78-1-1
-prophesy	prophesy	29.5-1
-proposal	propose	37.7-1 62 48.1.2
-proposition	propose	37.7-1 62 48.1.2
-prosecution	prosecute	33
-prospering	prosper	47.1-1 39.6
-prostitution	prostitute	29.8
-protection	protect	85
-protest	protest	71
-protesting	protest	71
-protrusion	protrude	47.6
-provision	provide	13.4.1-2
-provocation	provoke	31.1, 27.1-1
-publication	publish	26.4-1
-publishing	publish	26.4-1
-puckering	pucker	40.3.2 40.8.2
-pull	pull	11.4 12-1 23.2 40.8.3-1-1 15.1-1 13.5.1
-pulling	pull	11.4 12-1 23.2 40.8.3-1-1 15.1-1 13.5.1
-pulling_out	pull_out	82-1
-pulsation	pulsate	47.3
-pulse	pulse	47.3
-pumping	pump	9.7-1
-punch	punch	21.2-2 18.2
-punching	punch	21.2-2 18.2
-punctuation	punctuate	9.9
-punishment	punish	33
-purchase	purchase	13.5.2-1
-pursuit	pursue	51.6
-push	push	23.2 9.3-1-1 11.4-1-1 15.1-1 12-1-1
-quadrupling	quadruple	45.4
-qualification	qualify	29.6
-quarreling	quarrel	36.4
-question	question	37.1.3
-questioning	question	37.1.3
-quotation	quote	37.1.1
-quote	quote	37.1.1
-racing	race	51.3.2-2
-radiation	radiate	43.4
-rage	rage	47.2
-raid	raid	35.4
-raise	raise	40.3.2 9.4
-raising	raise	40.3.2 9.4
-rambling	ramble	51.3.2-1
-ranking	rank	29.6 29.2
-ranting	rant	37.3 37.11-1
-rating	rate	29.6 29.1 54.4
-ration	ration	13.3
-rationing	ration	13.3
-re-creation	recreate	26.4
-re-education	reeducate	37.1.1
-re-election	reelect	29.1
-reaction	react	31.3-9
-readiness	ready	26.3-1
-reading	read	14-1 54.1-1 84-1-1 37.1.1-1
-reaffirmation	reaffirm	31.2 29.5-2 78-1-1
-realization	realize	29.5-1 84
-reapproximation	approximate	34.2 54.4
-reasoning	reason	97.2
-rebellion	rebel	71
-rebuilding	rebuild	26.4
-recall	recall	10.2
-receding	recede	51.1
-reception	receive	13.5.2
-recertification	recertify	29.2
-recession	recede	51.1
-recirculation	recirculate	47.3
-recital	recite	26.7-1-1 37.1.1
-reckoning	reckon	70 29.9-1
-recognition	recognize	29.9 30.2 29.5
-recognition	recognize	33
-recollection	recollect	29.2-1-1
-recommendation	recommend	37.7-1-1-1
-reconstitution	reconstitute	26.4-1
-recording	record	25.4
-recovery	recover	13.5.2
-recreation	recreate	26.4
-recruiting	recruit	29.7 13.5.3
-recruitment	recruit	29.7 13.5.3
-redemption	redeem	10.5
-reduction	reduce	42.3 76
-reeducation	reeducate	37.1.1
-reelection	reelect	29.1
-referral	refer	13.2
-referring	refer	13.2
-reflection	reflect	31.3-8
-refund	refund	13.1
-regard	regard	30.2 29.2
-register	register	54.1-1
-registration	register	101
-regret	regret	31.2-1
-rehydration	hydrate	45.4
-reinjection	inject	9.8
-reiteration	reiterate	37.7-1
-rejection	reject	77
-rejuvenation	rejuvenate	31.1
-relaxation	relax	31.1
-relay	relay	37.4 37.1.1
-release	release	80-1
-releasing	release	80-1
-reliance	rely	70
-relief	relieve	10.6
-remaining	remain	47.1-1
-remark	remark	37.7-1 37.11-1
-remarriage	remarry	22.2-3-1-1
-remembering	remember	29.2-1-1 29.9-1-1-1
-remembrance	remember	29.2-1-1 29.9-1-1-1
-removal	remove	10.2 10.1 10.10
-remuneration	remunerate	33
-rendering	render	13.1
-rendition	render	13.1
-renegotiation	renegotiate	36.1
-renomination	nominate	29.1
-rental	rent	13.1-1
-rental	rent	13.5.1
-renting	rent	13.1-1
-renting	rent	13.5.1
-reopening	reopen	45.4
-reorganization	reorganize	26.4-1
-repayment	pay	68-1
-repeat	repeat	37.7-1 26.8 55.4
-repetition	repeat	37.7-1 26.8 55.4
-replacement	replace	13.6
-replay	replay	26.7-2-1
-reply	reply	37.7
-report	report	37.7-1 29.2-1-2 29.9-1
-reporting	report	37.7-1 29.2-1-2 29.9-1
-representation	representation	29.2-1-1
-reproduction	reproduce	45.4
-request	request	58.2
-requirement	require	103 60-1
-rescue	rescue	10.5
-reservation	reserve	13.5.1
-residence	reside	47.1-1 46
-resonance	resonate	47.4
-resort	resort	26.6.2
-respect	respect	31.2
-responding	respond	37.7
-response	respond	37.7
-rest	rest	47.6 9.2-1
-resting	rest	47.6 9.2-1
-restitution	restore	13.2
-restoration	restore	13.2
-restraint	restrain	67 76
-restriction	restrict	76
-resumption	resume	55.1-1
-retaliation	retaliate	71
-retirement	retire	10.11 82-3
-retracting	retract	10.1
-retraction	retract	10.1
-retreat	retreat	51.1 82-3
-retrieval	retrieve	13.5.2
-return	return	11.1 13.2-2
-return	return	26.6.2
-return	return	51.1
-revelation	reveal	37.10 37.7-1 29.2-1-2 78-1-1 48.1.2
-reversal	reverse	45.4
-reverse	reverse	45.4
-reversion	revert	26.6.2
-revitalization	revitalize	31.1
-revival	revive	45.4
-ride	ride	51.4.2
-riding	ride	51.4.2
-ring	ring	43.2
-ringing	ring	43.2
-ripening	ripen	45.4
-ripple	ripple	9.8 47.2
-rise	rise	45.6-1 47.6 51.1 50 48.1.1
-risk	risk	94-1
-roll	roll	26.1 9.6 47.4 23.2 22.3-2 40.3.2 51.3.2-2 43.2 11.2-1 51.3.1 45.2 26.3-1
-rolling	roll	26.1 9.6 47.4 23.2 22.3-2 40.3.2 51.3.2-2 43.2 11.2-1 51.3.1 45.2 26.3-1
-rotation	rotate	47.3 9.6 51.3.1
-round	round	47.7
-rowing	row	11.5 51.4.2
-rubbing	rub	40.3.2 20-1 10.4.1-1 9.7-1
-ruin	ruin	44
-run	run	47.5.1-1 51.3.2-2-1
-run_up	run_up	47.7
-running	run	11.4
-running	run	18.4
-running	run	47.5.1-1 51.3.2-2-1
-running	run	47.7
-rush	rush	51.3.2-2-1
-sacking	sack	10.10
-sacrifice	sacrifice	13.2-1-1
-sailing	sail	51.4.2
-sale	sell	13.1-1
-salivation	salivate	31.3-8 40.1.1
-salutation	salute	40.3.3 33
-salvage	salvage	10.5-1
-satiation	satiate	31.1
-satisfaction	satisfy	31.1
-saturation	saturate	9.8
-saving	save	13.5.1-1
-saving	save	13.5.1-1 54.5
-scaling	scale	10.7
-scalloping	scallop	45.3
-scanning	scan	30.2 35.4
-scare	scare	31.1
-scaring	scare	31.1
-scarring	scar	25.1
-scattering	scatter	9.7-1
-scheduling	schedule	26.4-1
-schmoozing	schmooze	37.6
-scolding	scold	33
-scooping	scoop	9.3
-scratching	scratch	40.8.3-2 10.4.1-1 21.1-1 18.2
-scream	scream	37.3
-scruple	scruple	53.1-1
-sculpting	sculpt	26.1-1
-search	search	35.2
-searching	search	35.2
-seasoning	season	9.8
-seclusion	seclude	16
-seduction	seduce	59-1
-seeding	seed	9.9 9.7-1
-seeking	seek	35.1
-segregation	segregate	23.3 23.1-1
-seizure	seize	15.1, 13.5.2, 10.5
-selection	select	13.5.2 29.2
-selling	sell	13.1-1
-sensation	sense	30.1-1
-sense	sense	30.1-1
-sensing	sense	30.1-1
-separation	separate	10.1 29.10 23.1-2
-sequestering	sequester	10.5 16
-service	serve	13.4.1-1
-service	serve	29.6-2 104
-servicing	serve	13.4.1-1
-serving	serve	13.4.1-1
-serving	serve	29.6-2 104
-serving_up	serve_up	13.4.1-1
-setting	set	41.2.2 25.1 9.1-2
-settlement	settle	89
-shading	shade	85
-shadowing	shadow	51.6
-shaking	shake	47.3 40.3.2 9.3-1-1 31.1 40.6 26.5
-shame	shame	31.1
-shaming	shame	31.1
-shaming	shame	59-1 33
-shape	shape	27 26.1-1 48.1.2
-shaving	shave	41.2.1 41.1.1 10.4.1
-shearing	shear	10.4.2-1
-shedding	shed	43.4
-shift	shift	26.6.2 45.6 11.1
-shifting	shift	26.6.2 45.6 11.1
-shipbuilding	shipbuilding	26.1-1
-shipping	ship	11.1-1
-shock	shock	31.1
-shoot	shoot	42.2
-shooting	shoot	42.2
-shopping	shop	35.2
-shortening	shorten	45.4
-shot	shoot	17.1-1
-show	show	37.1.1-1-1 40.3.2 29.5-2 78-1-1 48.1.2
-shower	shower	57 41.1.1 17.2 9.7-1
-showing	show	37.1.1-1-1 40.3.2 29.5-2 78-1-1 48.1.2
-showing_off	show_off	48.1.2
-shunting	shunt	11.1
-sight	see	29.2-1 30.1-1 29.9-1-1
-sign	signal	37.4
-signal	signal	37.4
-signing	sign	13.5.3
-signing	sign	25.1
-signing_up	sign_up	13.5.3
-simulation	simulate	55.5-1
-singing	sing	37.3 26.7-1-1 43.2
-sink	sink	45.4
-sinking	sink	45.4
-sitting	sit	47.6 9.2-1 50
-skateboarding	skateboard	51.4.1-1
-skiing	ski	51.4.1-1
-skimming	skim	10.4.1
-skirmish	skirmish	36.4-1
-slash	slash	21.1-1
-slaughter	slaughter	42.1 13.5.1
-slaying	slay	42.1
-sleeping	sleep	40.4
-slide	slide	51.3.2-2 51.3.1 11.2-1
-slowing	slow	45.4
-smack	smack	40.3.2
-smashing	smash	18.1-1 17.1-1 45.1 21.2-1
-smashing	smash	18.4-1
-smell	smell	35.3 30.1
-smuggling	smuggle	11.1-1 10.5-1
-snacking	snack	39.5
-sneezing	sneeze	40.1.1 40.2
-snoring	snore	40.1.1 40.2
-soaking	soak	9.8 10.4.1 45.4
-sobbing	sob	40.2
-softening	soften	45.4
-soiling	soil	9.8
-solution	solve	84
-solving	solve	84
-sound	sound	47.4 43.2
-sowing	sow	9.7-1
-span	span	47.8
-speaking	speak	37.5 37.11-1
-specification	specify	29.2
-speculating	speculate	29.5-1
-speculation	speculate	29.5-1
-speech	speak	37.5 37.11-1
-speeding	speed	51.3.2-2
-spelling	spell	25.2
-spending	spend	68
-spin	spin	9.6 40.8.2 51.3.1
-spin	spin	26.7-2-1
-spinning	spin	9.6 40.8.2 51.3.1
-spinning	spin	26.1
-spinning	spin	26.7-2-1
-spitting	spit	40.1.2
-splaying	splay	45.2
-split	split	23.2
-splitting	split	23.2
-spotting	spot	9.8
-spotting	spot	30.2
-spraying	spray	9.7-1
-spread	spread	9.7-1
-spread	spread	48.1.1
-spreading	spread	9.7-1
-spreading	spread	48.1.1
-spying	spy	30.2
-squeeze	squeeze	20-1 12-1-1 26.5
-squeezing	squeeze	20-1 12-1-1 26.5
-squinting	squint	40.3.1-1 30.3
-stab	stab	19 42.2 18.2
-stabbing	stab	19 42.2 18.2
-stabilization	stabilize	45.4
-stagflation	inflate	45.4
-staging	stage	26.4 55.5
-stagnation	stagnate	45.5
-staining	stain	24 9.9 9.8-1
-stalking	stalk	35.3
-stall	stall	53.1-1
-staring	stare	30.3
-start	start	55.1-1
-starting	start	55.1-1
-starvation	starve	40.7
-statement	state	37.7-1
-stay	stay	47.1-1 46
-steering	steer	51.7
-stem	stem	48.1.1
-step	step	51.3.2
-sterilization	sterilize	45.4
-stiffening	stiffen	45.4
-stigmatization	stigmatize	33
-stimulation	stimulate	59-1 31.1
-sting	sting	20-1 31.1 40.8.2
-stinging	sting	20-1 31.1 40.8.2
-stocking	stock	9.7-2 15.2
-stop	stop	55.4-1
-stoppage	stop	55.4-1
-storage	store	15.2
-straining	strain	40.8.3-2
-stratification	stratify	45.4
-stream	stream	48.1.1
-strengthening	strengthen	45.4
-stress	stress	31.3-2
-stressing	stress	9.9
-stretching	stretch	40.3.2 47.7 45.2
-stride	stride	51.3.2-1
-strike	strike	18.1-1 18.4-1
-stripping	strip	10.6 41.1.1 10.4.1-1
-stroke	stroke	25.2 20
-stroll	stroll	51.3.2-1
-struggle	struggle	36.4-1
-struggling	struggle	36.4-1
-study	study	14-1 30.2 34.1 84-1-1
-studying	study	14-1 30.2 34.1 84-1-1
-stuttering	stutter	37.3
-submission	submit	13.2-1-1
-submission	submit	95
-substitution	substitute	13.6-1-1
-success	succeed	74-1
-suction	suction	10.4.1-1
-suffering	suffer	31.3
-suggestion	suggest	37.7-1-1
-supersaturation	supersaturate	45.4
-supply	supply	13.4.1-1
-support	support	31.2 47.8 72
-supposition	suppose	29.9-2
-suppression	suppress	16 42.3
-surprise	surprise	31.1
-surrender	surrender	13.2-1-1
-surrounding	surround	9.8
-surveilance	surveil	30.2 35.4
-survey	survey	30.2 35.4
-survival	survive	47.1-1-1 39.6
-suspension	suspend	9.2-1
-suspension	suspension	10.10
-suspicion	suspect	29.5-1 81 29.9-2
-suturing	suture	22.4
-swallowing	swallow	39.3-2 40.1.1
-swat	swat	18.2
-sweating	sweat	40.1.2 43.4
-sweep	sweep	9.3-1-1 10.4.1-1
-sweep	sweep	35.2
-sweep	sweep	47.7 51.3.2-1
-sweeping	sweep	9.3-1-1 10.4.1-1
-swelling	swell	45.5 45.6-1
-swim	swim	47.5.1 51.3.2
-swimming	swim	47.5.1 51.3.2
-swing	swing	47.6 51.3.1 9.6-1
-swipe	swipe	10.5
-switch	switch	26.6.2-1 13.6-1
-switching	switch	26.6.2-1 13.6-1
-tackle	tackle	98
-tag	tag	9.9 25.3
-takeover	take_over	93
-taking	take	10.5 11.3
-taking	take	26.6.2
-taking	take	29.2
-taking	take	103 54.2 54.3
-taking_on	take_on	93
-taking_on	take_on	98
-taking_over	take_over	93
-talk	talk	37.5 37.11-1
-talking	talk	37.5 37.11-1
-tanning	tan	45.4
-tapering_off	taper_off	45.4
-tapping	tap	18.1-1 17.1-1
-tariff	tax	54.5
-taste	taste	30.4
-taste	taste	35.3 30.1
-tasting	taste	35.3 30.1
-tattooing	tattoo	25.1
-taxation	tax	54.5
-teaching	teach	37.1.1-1-1
-tearing	tear	23.2 40.8.3-1-1 45.1
-tearing	tear	51.3.2
-teasing	tease	59-1 31.1
-teething	teethe	39.2-1
-telling	tell	37.1.1-1-1 37.2-1
-temptation	tempt	59 31.1
-tension	tense	45.4
-termination	terminate	10.10
-termination	terminate	55.4
-terror	terrorism	31.1
-terrorising	terrorize	31.1
-terrorizing	terrorize	31.1
-test	test	35.4
-testimony	testify	37.11-1
-testing	test	35.4
-thanks	thank	33
-thawing	thaw	45.4
-theft	thieve	10.5
-thickening	thicken	45.4
-thieving	thieve	10.5
-thinking	think	29.9-2 62
-thinning	thin	45.4
-thought	think	29.9-2 62
-threat	threaten	31.1
-thrill	thrill	31.1
-throw	throw	17.1-1-1
-throwing	throw	17.1-1-1
-thrust	thrust	11.4-1-1 12-1-1
-thumping	thump	18.4-1 18.3 18.1
-thumping	thump	43.2
-tickling	tickle	20-1 31.1 40.8.2
-tightening	tighten	45.4
-tiling	tile	9.8 9.9
-timing	time	54.1
-tingling	tingle	40.8.2
-tip	tip	17.1-1-1
-tip	tip	54.5
-tiptoeing	tiptoe	51.3.2
-tolerance	tolerate	31.2 64
-torture	torture	31.1
-toss	toss	40.3.2 17.1-1-1 26.3-1
-tossing	toss	40.3.2 17.1-1-1 26.3-1
-touch	touch	20-1 31.1 86.2-1 47.8-1
-touching	touch	20-1 31.1 86.2-1 47.8-1
-touching_on	touch_on	86.2-1
-tow	tow	11.4
-towing	tow	11.4
-tracing	trace	25.2
-track	track	35.3 51.6
-tracking	track	35.3 51.6
-trade	trade	13.6-1
-trading	trade	13.6-1
-training	train	13.5.3
-transcription	transcribe	25.4
-transfer	transfer	11.1 13.2-2
-transformation	transform	26.6.1
-translation	translate	26.6.1
-transmission	transmit	11.1-1
-transmutation	transmute	26.6.1
-transport	transport	11.1
-transportation	transport	11.1
-trapping	trap	9.10
-travel	travel	51.3.2-1
-traveling	travel	51.3.2-1
-travelling	travel	51.3.2-1
-treating	treat	13.4.2-1
-treating	treat	29.2
-treatment	treat	29.2
-tremor	tremor	47.3 40.6
-trick	trick	59
-tunneling	tunnel	35.5-1
-turn	turn	26.6.2 26.6.1-1
-turn	turn	40.3.2 47.7 40.8.3-1-1 51.3.1
-turnabout	turnabout	26.6.2 26.6.1
-turnabout	turnabout	40.3.2 47.7 40.8.3 51.3.1
-turning	turn	40.3.2 47.7 40.8.3-1-1 51.3.1
-tutoring	tutor	29.8-1
-twist	twist	26.5 9.6-1
-twitching	twitch	40.3.2 49
-typing	type	25.2 25.4
-typing_up	type_up	25.2 25.4
-ulceration	ulcerate	45.4
-ultrafiltration	ultrafilter	45.4
-underestimation	underestimate	29.2-1
-understanding	understand	accept-77.1 comprehend-87.2-1
-undertaking	undertake	55.1 98
-undoing	undo	44
-unification	unify	22.2
-union	union	45.4
-unloading	unload	10.4.1
-update	update	37.2
-upgrade	upgrade	29.1
-urbanization	urbanize	45.4
-urging	urge	58.1
-urination	urinate	40.1.3-1 40.1.2-1
-use	use	66, 105.1, 39.1-3
-using	use	66, 105.1, 39.1-3
-utilization	utilize	105
-vacation	vacation	56
-vacuuming	vacuum	10.4.2-1
-valuation	value	54.4
-variation	vary	23.4 45.6-1 45.4
-vault	vault	51.3.2-1
-ventilation	ventilate	45.4
-verification	verify	101 37.1.1 78-1-1
-vexation	vex	31.1
-vibration	vibrate	47.3 45.4
-view	view	29.2-1 29.9-1
-view	view	30.2
-viewing	view	30.2
-visit	visit	36.3-1
-visiting	visit	36.3-1
-visualization	visualize	29.2-1-1
-vocalization	vocalize	37.7
-voice	voice	37.7
-volunteering	volunteer	37.7 29.8
-vomiting	vomit	40.1.2
-vote	vote	29.3
-voting	vote	29.3
-voyage	voyage	51.4.2
-waiting	wait	47.1-1
-walk	walk	51.3.2
-walking	walk	51.3.2
-war	war	36.4-1
-warfare	war	36.4-1
-warming	warm	45.4
-warning	warn	37.9-1
-washing	wash	41.2.1 41.1.1 10.4.1-1 26.3-2
-waste	waste	44 68 66-1
-wasting	waste	44 68 66-1
-watch	watch	35.2 30.2
-watching	watch	35.2 30.2
-watering	water	9.9
-wave	wave	47.3 40.3.1-1
-waxing	wax	41.2.2 9.9
-waxing	wax	48.1.1
-weakening	weaken	45.4
-weaning	wean	10.6
-wedding	wed	22.2-3-1-1
-weeping	weep	40.1.2 31.3-3 40.2
-welcome	welcome	33 65
-westernization	westernize	45.4
-wetting	wet	45.4
-whack	whack	18.1
-wheezing	wheeze	40.1.1 43.2
-whining	whine	37.3 38 37.8 43.2
-whitewash	whitewash	10.6
-whooping	whoop	37.3
-whooshing	whoosh	43.2
-widening	widen	45.4
-win	win	13.5.1
-winning	win	13.5.1
-wish	wish	32.2-1 62
-withdrawal	withdraw	10.1 10.11 51.1 82-3
-wonder	wonder	31.3-1
-work	work	39.6
-working	work	26.5
-worrying	worry	31.3-2
-wreck	wreck	44
-wrestling	wrestle	36.4-1
-wringing	wring	40.3.2 20-1
-write	write	26.7-2-1 25.2 37.1.1-1-1 37.7 37.11-1
-writing	write	26.7-2-1 25.2 37.1.1-1-1 37.7 37.11-1
-yapping	yap	37.3 38
-yawning	yawn	40.1.1 40.2
-yelling	yell	37.3 38
-yellowing	yellow	45.4
+abbreviation	abbreviate	45.4	1
+abdication	abdicate	10.11	0
+abduction	abduct	10.5	6
+ablation	ablate	10.1	0
+abolition	abolish	10.1	4
+abrasion	abrade	45.4	1
+abstention	abstain	69	0
+abstraction	abstract	10.1	1
+acceleration	accelerate	45.4	8
+acceptance	accept	77.1 13.5.2 29.2-1-1	11
+accommodation	accommodate	26.9	11
+accompaniment	accompany	51.7	4
+accumulation	accumulate	13.5.2 47.5.2	15
+accusation	accuse	81	20
+achievement	achieve	55.2	48
+aching	ache	40.8.2	1
+acknowledgment	acknowledge	37.10 29.9-1	1
+acquisition	acquire	13.5.2-1	10
+activating	activate	45.4	3
+activation	activate	45.4	3
+adaptation	adapt	26.9	7
+adaption	adapt	26.9	7
+addiction	addict	96	18
+addition	add	22.1-2 108	164
+adhesion	adhere	22.5	0
+adjustment	adjust	26.9	40
+administration	administer	13.2-1-1	61
+admiration	admire	31.2	1
+admonition	admonish	37.9-1 58.1	0
+adoption	adopt	29.1 93 29.2	19
+advance	advance	102 45.4	55
+advertisement	advertise	35.2	24
+advertising	advertise	35.2	24
+advice	advise	37.9-1 37.2 37.7-1 58.1	3
+affiliation	affiliate	22.2-2	12
+affirmation	affirm	78-1-1 31.2 29.5-2	6
+affliction	afflict	31.1	0
+agglomeration	agglomerate	45.4	0
+aggravation	aggravate	31.1	1
+aggregation	aggregate	47.5.2	2
+aging	age	45.4	4
+agitation	agitate	31.1	5
+aim	aim	intend-61.2 wish-62	43
+airing	air	45.4	0
+alert	alert	37.9	7
+alienation	alienate	31.1	4
+allegation	allege	37.7	31
+alliance	ally	71	0
+allocation	allocate	13.3	20
+allotment	allot	13.3	7
+allowance	allow	64.1-1 64.3	6
+alteration	alter	26.6.1 45.4	7
+alternation	alternate	22.2-2-1 86.1	4
+amalgamation	amalgamate	22.2-1-1 22.1-1-1	4
+ambulation	ambulate	51.3.2	0
+amplification	amplify	45.4 37.12	1
+amusement	amuse	31.1	2
+analysis	analyze	34.1	75
+analyze	analyze	34.1	75
+animation	animate	45.4	0
+annexation	annex	10.5	1
+annihilation	annihilate	44 42.1	3
+annnunciation	announce	48.1.2 37.7-1	38
+annotation	annotate	25.1	0
+announcement	announce	48.1.2 37.7-1	38
+announcing	announce	48.1.2 37.7-1	38
+appeal	appeal	31.4-3	3
+appointment	appoint	29.1	41
+appraisal	appraise	54.4	15
+appreciation	appreciate	31.2	39
+approach	approach	98	99
+appropriating	appropriate	13.5.2	30
+appropriation	appropriate	13.5.2	30
+approximation	approximate	34.2 54.4	1
+arrangement	arrange	26.1 55.5-1 9.1	19
+arrival	arrive	51.1	38
+articulation	articulate	37.7-1	0
+ascending	ascend	47.7	0
+ascension	ascend	47.7	0
+ascent	ascend	47.7	0
+asphyxiation	asphyxiate	40.7 42.2	1
+assassination	assassinate	42.1	32
+assembly	assemble	26.1	5
+assertion	assert	29.5	5
+assessment	assess	34.1 54.4 34.2	56
+assignment	assign	13.3	16
+assimilation	assimilate	26.9 14-2-1	0
+association	associate	amalgamate-22.2-2	15
+assurance	assure	37.13 99 37.9	10
+attainment	attain	13.5.1	1
+attenuation	attenuate	45.4	0
+audit	audit	34.1	35
+augmentation	augment	45.4	0
+average	average	108-3	3
+averaging	average	108-3	3
+awakening	wake	45.4	0
+award	award	13.3	74
+baking	bake	45.3 26.3-1 26.1	1
+banding	band	22.3-2 22.4	0
+banking	bank	9.10	3
+bashing	bash	18.1 18.4-1	1
+bath	bathe	41.1.1 9.8	4
+bathing	bathe	41.1.1 9.8	4
+battering	batter	18.1-1	1
+batting	bat	40.3.2	0
+battle	battle	36.3-2 36.4-1	88
+beating	beat	18.1-1	12
+bedding	bed	9.10	5
+bedwetting	bedwet	45.4	0
+beginning	begin	55.1-1	119
+beheading	behead	42.2	0
+belching	belch	40.1.1	0
+bend	bend	50 45.2 47.6 26.5 47.7	1
+bending	bend	50 45.2 47.6 26.5 47.7	1
+bequest	bequeath	13.3	0
+bet	bet	94 54.5 70	19
+betting	bet	94 54.5 70	19
+bias	bias	96	0
+bickering	bicker	36.4-1	7
+bifurcation	bifurcate	45.4	0
+biking	bike	51.4.1-1 11.5	4
+billing	bill	54.5	13
+binding	bind	9.8 22.3-2-1	0
+bite	bite	18.2 40.8.3-2	9
+biting	bite	18.2 40.8.3-2	9
+blanking	blanking	10.4.1	0
+blaze	blaze	43.1	5
+bleeding	bleed	40.1.2 43.4-1	6
+blistering	blister	45.5	0
+blitz	blitz	44	0
+block	block	16 9.8	8
+blockade	blockade	9.8	15
+blockage	block	16 9.8	8
+blocking	block	16 9.8	8
+bloom	bloom	45.5 47.2	2
+blooming	bloom	45.5 47.2	2
+blossoming	blossom	47.2	1
+blowing_up	blow_up	23.2	0
+blunting	blunt	45.4	0
+blurring	blur	45.4	0
+boarding	board	46	1
+boast	boast	37.8	2
+boating	boat	51.4.1	0
+boil	boil	26.3-2 45.3	2
+bombardment	bombard	9.8	0
+bond	bond	shake-22.3-2-1 tape-22.4	13
+bonding	bond	shake-22.3-2-1 tape-22.4	13
+boost	boost	102	11
+borrowing	borrow	13.5.2	25
+botching	botch	45.4	0
+bounce	bounce	51.3.2-2 51.3.1 11.2-1	8
+bow	bow	40.3.3	1
+bowling	bowl	51.3.2-2	6
+boxing	box	36.3-2	1
+boycott	boycott	52	4
+brawl	brawl	36.4-1	0
+brawling	brawl	36.4-1	0
+break_up	break_up	45.1	0
+breakdown	break_down	45.1	0
+breaking_off	break_off	23.2	0
+breakup	break_up	45.1	0
+breastfeeding	breastfeed	39.7	2
+breath	breathe	40.1.2-1	21
+breathing	breathe	40.1.2-1	21
+briefing	brief	37.9	2
+broadening	broaden	45.4	1
+bruising	bruise	40.8.3-2 21.2-1	0
+brushing	brush	41.2.1 10.4.2-1 41.2.2	0
+budding	bud	45.5	0
+build	build	26.1-1	16
+building	build	26.1-1	16
+bulging	bulge	47.5.3 47.2	0
+bullying	bully	29.8-1	0
+burden	burden	13.4.2-1-1	58
+burial	bury	9.1-1	10
+burn	burn	45.4 40.8.3-2 45.5 43.1	17
+burning	burn	45.4 40.8.3-2 45.5 43.1	17
+burping	burp	40.1.1	0
+buying	buy	13.5.1	5
+buyout	buy_out	13.5.1	0
+calcification	calcify	45.4	2
+calcifying	calcify	45.4	2
+call	call	13.5.1	174
+calling	call	13.5.1	174
+camping	camp	46	0
+cancerization	cancerize	45.4	0
+canning	can	10.10	0
+cap	cap	9.9	25
+capture	capture	10.5-1	12
+care	care	31.3	142
+caring	care	31.3	142
+cascading	cascade	47.7	0
+casting	cast	26.1	4
+castration	castrate	45.4	0
+castration	castrate	45.4	0
+castration	castrate	45.4	0
+catalog	catalogue	29.10	0
+catalogue	catalogue	29.10	0
+catch	catch	13.5.1	5
+catching	catch	13.5.1	5
+categorization	categorize	29.10 45.4	2
+causation	cause	27.1-1, 27.2	0
+caution	caution	37.9-1	7
+certification	certify	29.2	7
+cessation	cease	55.4-1	10
+change	change	45.4 26.6.1-1	184
+changing	change	45.4 26.6.1-1	184
+characterization	characterize	29.2-1	1
+chase	chase	51.6	11
+chasing	chase	51.6	11
+chat	chat	37.6	24
+chatting	chat	37.6	24
+check	check	35.2	24
+check_up	check_up	35.2	0
+checking	check	35.2	24
+chewing	chew	39.2-1	0
+chlorination	chlorinate	45.4	2
+choice	choose	13.5.1	134
+choking	choke	40.7	0
+choosing	choose	13.5.1	134
+chop	chop	21.2-2 21.1-1 18.2	1
+circularisation	circularize	13.2-1-1	4
+circumcision	circumcise	45.4	2
+civilization	civilize	45.4	1
+claim	claim	37.7-1	29
+clapping	clap	43.2	1
+clarification	clarify	45.4	0
+clash	clash	36.4-1	78
+classification	classify	29.2 29.10	7
+cleaning	clean	10.3 45.4 26.3-2	15
+cleaning	clean_up	26.3-2 45.4 10.3	0
+cleavage	cleave	21.2-1	2
+clenching	clench	40.3.2	0
+click	click	18.1 43.2 40.3.2	2
+climb	climb	51.3.2, 51.1-1-3	4
+climbing	climb	51.3.2, 51.1-1-3	4
+clip	clip	21.1-1 41.2.2	1
+clogging	clog	9.8 45.4	1
+close	close	45.4 40.3.2	41
+closing	close	45.4 40.3.2	41
+clothing	clothe	41.1.1	1
+clouding	cloud	45.4	0
+clubbing	club	18.3	0
+clubbing	clubbing	47.3 26.7	0
+clunking	clunk	43.2	0
+co-existence	coexist	47.1-1	0
+coagulation	coagulate	45.4	0
+coating	coat	9.8	9
+coblation	ablate	10.1	0
+coding	code	29.10	2
+coding	code	29.10	2
+coexistence	coexist	47.1-1	0
+collaborating	collaborate	71	1
+collaboration	collaborate	71	1
+collapse	collapse	45.4	25
+collecting	collect	13.5.2 47.5.2 22.3-2 45.4 26.5	43
+collection	collect	13.5.2 47.5.2 22.3-2 45.4 26.5	43
+collision	collide	18.4-1 18.4	22
+collusion	collude	71	0
+coloration	color	24	2
+coloring	color	24	2
+combat	combat	36.4-1	13
+combination	combine	22.1-1-1	17
+combustion	combust	45.4	3
+coming	come	51.1	9
+comment	comment	37.11-1-1	113
+commentary	comment	37.11-1-1	113
+commercialization	commercialize	45.4	3
+commitment	commit	79 92-1	23
+communicating	communicate	37.1.1 36.4-1	70
+communication	communicate	37.1.1 36.4-1	70
+comparison	compare	22.2-2	33
+compensation	compensate	13.4.2-1-1	45
+competition	compete	36.4-1	92
+compilation	compile	26.1	5
+complaining	complain	37.8	30
+complaint	complain	37.8	30
+completion	complete	55.2	31
+composition	compose	26.4	8
+comprehension	comprehend	87.2-1	7
+compression	compress	26.5	4
+computation	compute	26.4	0
+concern	concern	31.1	449
+concession	concede	13.3	4
+conclusion	conclude	97.2	14
+condemnation	condemn	81	1
+condensation	condense	45.4	0
+conditioning	condition	41.2.2	12
+confederation	confederate	22.2-2	12
+conference	confer	37.6	258
+confession	confess	37.10 37.7-1	19
+confirmation	confirm	78-1-1 29.5-2	26
+confiscation	confiscate	10.5	6
+conflict	conflict	36.4-1	151
+confrontation	confront	98	59
+confusion	confuse	amalgamate-22.2-2 amuse-31.1	43
+conglomeration	combine	22.1-1-1	17
+congregation	congregate	47.5.2	7
+conization	conization	10.1	0
+connecting	connect	22.1-2-1 22.4	87
+connection	connect	22.1-2-1 22.4	87
+conquering	conquer	42.3	0
+conquest	conquer	42.3	0
+conservation	conserve	13.5.1	12
+consideration	consider	29.9-1-1-1	17
+consolation	console	31.1	4
+consolidation	consolidate	22.2-1-1 22.1-1 22.2-2-1	15
+conspiracy	conspire	71	0
+constitution	constitute	55.5	0
+construction	construct	26.4 45.4	302
+consult	consult	36.3-1 37.1.2 36.4	27
+consultation	consult	36.3-1 37.1.2 36.4	27
+consulting	consult	36.3-1 37.1.2 36.4	27
+consuming	consume	66	40
+consumption	consume	66	40
+containment	contain	54.3 47.8	6
+contamination	contaminate	9.8	7
+content	content	31.1	2
+contention	contend	36.4	0
+continuation	continue	55.3 55.6	15
+contracting	contract	45.4	13
+contraction	contract	45.4	13
+contrast	contrast	22.2-2-1	70
+contribution	contribute	13.2-1-1	73
+convening	convene	47.5.2	33
+convention	convene	47.5.2	33
+convergence	converge	87.1 47.7	3
+conversation	converse	37.6	46
+conversion	convert	26.6.1-1 26.6.2-1	11
+conveyancing	conveyancing	11.1	2
+convulsion	convulse	40.6	1
+cooking	cook	45.3 26.3-1 26.1	3
+cooling	cool	45.4	3
+coping	cope	83-1	0
+copy	copy	25.4 25.2	54
+copying	copy	25.4 25.2	54
+correction	correct	45.4	16
+correlation	correlate	22.2-2-1 86.1	12
+corrosion	corrode	45.4 45.5	1
+corruption	corrupt	45.4	105
+cost	cost	54.2	9
+cough	cough	40.1.2-1	37
+coughing	cough	40.1.2-1	37
+counseling	counsel	37.9-1	26
+count	count	108 34.2	18
+counting	count	108 34.2	18
+coupling	couple	22.2-1	0
+coverage	coverage	9.8 47.8	0
+crabbing	crab	13.7	1
+crash	crash	18.4-1 45.1 43.2	29
+craving	crave	32.1 32.2-1	3
+creation	create	26.4, 27.1	35
+credit	credit	13.4.1-1	38
+crepitation	crepitate	43.2	0
+crossing	cross	51.1-1-3, 47.7	8
+crossing_out	cross_out	40.3.2	0
+crusting	crust	45.5	0
+cry	cry	37.3	6
+crying	cry	37.3	6
+crying_out	cry_out	37.3	0
+cuddling	cuddle	36.2	0
+cultivation	cultivate	26.3-1	13
+curb	curb	42.3	7
+cycling	cycle	51.4.1-1	4
+damage	damage	44	273
+dampening	dampen	42.3	0
+dampening	dampen	45.4	0
+dance	dance	51.5	31
+dancing	dance	51.5	31
+darkening	darken	45.4	0
+dating	date	36.2	9
+dazzling	dazzle	31.1	0
+deal	deal	83	209
+dealing	deal	83	209
+death	die	48.2	576
+debate	debate	36.3-2 37.6	84
+debriefing	debrief	37.9	0
+deceleration	decelerate	45.4	0
+decision	decide	13.5.1	282
+declaration	declare	48.1.2 37.7-1	51
+decomposition	decompose	45.5	0
+decompression	decompress	45.4	0
+deconditioning	decondition	41.2.2	0
+decoration	decorate	25.3 9.8	8
+decrease	decrease	45.4	13
+dedication	dedicate	79	14
+deduction	deduct	10.1 108-2	2
+deepening	deepen	45.4	0
+defecation	defecate	40.1.2-1	1
+defence	defend	85	21
+defense	defend	85	21
+definition	define	29.2-1-1 48.1.2	59
+deflation	deflate	45.4	0
+deforestation	deforest	10.8	0
+deformation	deform	26.6.1	1
+degeneration	degenerate	45.4	4
+degradation	degrade	45.4	9
+dehydration	dehydrate	45.4	1
+delay	delay	53.1-1	24
+deleting	delete	10.1	3
+deletion	delete	10.1	3
+deliberation	deliberate	36.3-1	0
+delivery	deliver	11.1	52
+demand	demand	103	70
+demolition	demolish	44 31.1	11
+demonstration	demonstrate	78-1-1 37.1.1	71
+demoralization	demoralize	31.1	1
+dent	dent	21.2-1	3
+departure	depart	51.1-1 10.11	23
+dependency	depend	70	0
+depiction	depict	29.2	4
+deportation	deport	10.2	3
+deposit	deposit	9.1-1	15
+deposition	deposit	9.1-1	15
+depression	depress	31.1	45
+derivation	derive	26.4 97.2	0
+desalination	desalinate	45.4	0
+desalinization	desalinate	45.4	0
+desaturation	desaturate.	45.4	0
+descending	descend	47.7	0
+description	describe	29.2-1-1	28
+desecration	desecrate	44	5
+design	design	26.4-1	50
+designation	designate	29.1	5
+desire	desire	32.1	5
+destabilization	destabilize	45.4	4
+destruction	destroy	44	93
+detachment	detach	23.3	1
+detection	detect	30.1-1	3
+deterioration	deteriorate	45.5 45.4	22
+determination	determine	84 29.5-1	15
+devaluation	devalue	45.4	4
+devastation	devastate	44 31.1	14
+development	develop	26.1	204
+deviation	deviate	23.4	13
+devolution	devolve	13.3	0
+devotion	devote	79	27
+deworming	deworm	10.8	1
+diagnosis	diagnose	29.2	9
+dictating	dictate	37.1.1-1	2
+dictation	dictate	37.1.1-1	2
+die	die	48.2	576
+differentiation	differentiate	23.1-1	1
+diffraction	diffract	45.4	0
+diffusion	diffuse	45.4	2
+dig	dig	35.1	2
+digging	dig	35.1	2
+diminution	diminish	45.4	0
+dining	dine	39.5	1
+directing	direct	26.7-1	69
+direction	direct	26.7-1	69
+disagreement	disagree	36.4-1	0
+disappointment	disappoint	31.1	23
+disarmament	disarm	31.1	1
+disarming	disarm	31.1	1
+disclosure	disclose	78-1-1 37.7	6
+discontinuation	discontinue	55.2	1
+discovery	discover	84 30.2 29.5-2	23
+disgust	disgust	31.1	6
+dishonor	dishonor	31.1	0
+dishonour	dishonor	31.1	0
+disintegration	disintegrate	45.4	11
+dislocation	dislocate	45.4	5
+disorganization	disorganize	45.4	0
+display	display	48.1.2	14
+dispute	dispute	36.4-1	60
+dissatisfaction	dissatisfy	31.1	0
+dissemination	disseminate	13.2-1	3
+dissipation	dissipate	45.4	1
+dissociation	dissociate	23.1-2	0
+dissolution	dissolve	45.4	7
+distension	distend	45.2	2
+distention	distend	45.2	2
+distortion	distort	26.5	4
+distraction	distract	31.1	12
+distribution	distribute	13.2-1	30
+disturbance	disturb	31.1	11
+divergence	diverge	23.4	6
+diversification	diversify	45.4	10
+diversion	divert	31.1	12
+dividing	divide	23.1-1 45.4	43
+division	divide	23.1-1 45.4	43
+divorce	divorce	36.2	19
+dock	dock	9.10-1	9
+docking	dock	9.10-1	9
+dockings	dock	9.10-1	9
+documentation	document	25.4	19
+dogsledding	dogsled	51.4.1	0
+dominance	dominate	47.8-2	18
+domination	dominate	47.8-2	18
+dominion	dominate	47.8-2	18
+donation	donate	13.2-1-1	16
+doubling	double	45.4	6
+doubt	doubt	29.5-1	42
+douching	douche	41.2.1 41.1.1	0
+drafting	draft	26.4	0
+drag	drag	11.4 35.2	6
+draining	drain	10.3-1 45.4	2
+draw	draw	10.1 11.4 23.2	10
+draw_down	draw	10.1 11.4 23.2	10
+drawing	draw	10.1 11.4 23.2	10
+dream	dream	62	49
+dreaming	dream	62	49
+dredging	dredge	35.2	0
+dressing	dress	41.1.1	0
+dribbling	dribble	40.1.2	1
+drilling	drill	21.2-2	11
+drink	drink	39.1-2	43
+drinking	drink	39.1-2	43
+drive	drive	11.5	35
+drive_around	drive	11.5	35
+driving	drive	11.5	35
+drooling	drool	40.1.2 43.4	0
+drooping	droop	47.6	0
+drop	drop	9.4 45.6-1 51.3.1 47.7	55
+dropping	drop	9.4 45.6-1 51.3.1 47.7	55
+dueling	duel	36.4-1	1
+dumping	dump	9.3-1-1	0
+duplication	duplicate	25.4	1
+dusting	dust	9.7-2	4
+dying	die	48.2	576
+eating	eat	39.1-1	16
+echo	echo	47.4	2
+edification	edify	45.7	0
+educating	educate	37.9	183
+education	educate	37.9	183
+ejection	eject	10.1	0
+elaboration	elaborate	37.11-1-1	1
+election	elect	29.1	153
+electrocoagulation	coagulate	45.4	0
+electrodesiccation	desiccate	45.4	0
+elevation	elevate	9.4	0
+elimination	eliminate	10.1	10
+emancipation	emancipate	10.5	4
+employment	employ	13.5.3	33
+emptying	empty	10.3-1 45.4	0
+encouragement	encourage	37.9 58.1-1-1	33
+end	end	55.4-1	412
+ending	end	55.4-1	412
+endowment	endow	9.8	8
+engagement	engage	13.5.3 22.2-3-2 31.1	5
+eradication	eradicate	10.1	2
+erection	erect	26.1	0
+erosion	erode	45.5	6
+escape	escape	51.1-1	5
+establishment	establish	55.5-1 78-1-1 97.1	37
+estimate	estimate	54.4	19
+estimation	estimate	54.4	19
+evacuation	evacuate	10.2	6
+evaluation	evaluate	34.1	33
+evaporation	evaporate	45.4	4
+evasion	evade	52	10
+evening_out	even_out	45.4	0
+evolution	evolve	48.1.1, 26.2.1	35
+exaction	exact	13.5.2	0
+exam	examination	35.4	0
+examination	examination	35.4	0
+excavation	excavate	35.2	1
+excision	excise	10.1	0
+excitement	excite	31.1	3
+excommunication	excommunicate	10.1	1
+execution	execute	42.1	16
+exenteration	exenterate	10.8 42.2	0
+exercise	exercise	41.1.1	38
+exhaustion	exhaust	31.1	0
+exhibition	exhibit	48.1.2	27
+exile	exile	36.4	14
+existing	exist	39.6 47.1-1	0
+exit	exit	51.1-1	3
+expansion	expand	45.4	38
+expectation	expect	62 29.5-1	109
+experience	experience	30.2	228
+expiration	expire	48.2	11
+explanation	explain	37.1.1 78-1	86
+explosion	explode	45.4 43.2	61
+exposure	expose	48.1.2 78	27
+expression	express	48.1.2	30
+expulsion	expel	10.2 10.1	7
+extension	extend	47.1-1	7
+extermination	exterminate	44	0
+extortion	extort	10.5	7
+extracting	extract	10.1	4
+extraction	extract	10.1	4
+extradition	extradite	10.2	0
+extrapolating	extrapolate	108-2	0
+extrapolation	extrapolate	108-2	0
+extrusion	extrude	10.1	0
+fabrication	fabricate	26.4	11
+failing	fail	neglect-75.1-1 succeed-74-3-1-1	0
+failure	fail	neglect-75.1-1 succeed-74-3-1-1	0
+fainting	faint	40.8.4	2
+fall	fall	51.1	22
+falling	fall	51.1	22
+fancy	fancy	31.2 32.1	5
+farting	fart	40.1.1	1
+fascination	fascinate	31.1	0
+favor	favor	31.2	82
+favour	favor	31.2	82
+fear	fear	31.3, 31.2-1	100
+federation	federate	45.4	0
+feeding	feed	39.7 39.6	5
+feeling	feel	30.1-1-1, 30.3	80
+fermentation	ferment	45.5	1
+feud	feud	36.4-1	10
+feuding	feud	36.4-1	10
+fibrillation	fibrillate	45.4	1
+fight	fight	36.4-1 36.3-2	74
+fighting	fight	36.4-1 36.3-2	74
+file	file	9.10	16
+filing	file	9.10	16
+filling	fill	9.8 45.4 47.8	7
+filming	film	25.4	3
+filtration	filter	10.4.2	1
+find	find	84 13.5.1	16
+finding	find	84 13.5.1	16
+fine	fine	54.5	21
+fire	fire	17.1-1	43
+fishing	fish	35.1 13.7	20
+fissuring	fissure.	45.1	0
+fit	fit	54.3 9.3-1 26.9	4
+fitting	fit	54.3 9.3-1 26.9	4
+fix	fix	54.4 22.3-2	8
+fixation	fixate	87.1 22.3-2-1	4
+flaking	flake	21.2-1	0
+flash	flash	43.1 40.3.2	5
+flashing	flash	43.1 40.3.2	5
+flattening	flatten	21.2-1 45.4	0
+fleeing	flee	51.1-1	0
+flexion	flex	40.3.2	0
+flickering	flicker	43.1	0
+flight	flee	51.1-1	0
+flight	fly	51.3.2-2-1 11.5-1 51.4.2	161
+flipping	flip	17.1-1	2
+flood	flood	45.4 9.8	26
+flooding	flood	45.4 9.8	26
+flossing	floss	41.2.1	0
+flow	flow	47.2	32
+flushing	flush	10.4.1	0
+flushing	flush	40.1.1	0
+fluttering	flutter	40.3.2 47.3	0
+flying	fly	51.3.2-2-1 11.5-1 51.4.2	161
+foaming	foam	47.2 43.4	0
+formation	form	26.4 48.1.2	32
+formatting	format	55.5-1	0
+forming	form	26.4 48.1.2	32
+formulation	formulate	26.1 26.4	7
+forwarding	forward	11.1-1	1
+foundation	found	55.5-1 97.1	15
+founding	found	55.5-1 97.1	15
+freeze	freeze	45.4 57	8
+freezing	freeze	45.4 57	8
+fright	frighten	31.1	0
+frost	frost	45.4	1
+frustration	frustrate	31.1	26
+function	function	29.6	15
+functioning	function	29.6	15
+fusion	fuse	22.1-1-1 22.3-1-1	22
+gain	gain	13.5.1-1	11
+gamble	gamble	94 70	19
+gambling	gamble	94 70	19
+gauge	gauge	54.4 34.2	8
+germination	germinate	45.5	0
+gesture	gesture	40.3.1	11
+giving	give	13.1-1	0
+glare	glare	40.2 30.3	7
+glimpse	glimpse	30.2	1
+gossiping	gossip	37.6	0
+gouging	gouge	21.2-1	1
+grabbing	grab	15.1, 13.5.2, 10.5-1	1
+grading	grade	29.10	0
+grading	grade	45.4	0
+grafting	graft	22.3-2-1	0
+grant	grant	29.5-2 13.3	48
+granting	grant	29.5-2 13.3	48
+granulation	granulate	45.4	0
+grasp	grasp	87.2-1 20-1	4
+grievance	complain	37.8	30
+grinding	grind	40.3.2 26.1 21.2-1	0
+grip	grip	20-1	0
+groan	groan	40.2 37.3	0
+groaning	groan	40.2 37.3	0
+grooming	groom	41.1.2	1
+grooving	groove	9.9	0
+grouping	group	29.10 22.3-2 47.5.2	2
+growing	grow	26.2.1 26.1	2
+grumble	grumble	37.8 37.3	3
+guarantee	guarantee	99 37.13 29.5-2 13.3	34
+guarding	guard	29.8-1	0
+guess	guess	29.5-1	17
+guidance	guide	51.7	20
+gushing	gush	43.4	0
+gutting	gut	10.7	1
+hacking	hack	21.1-1 26.1	0
+hacking	hack	23.2	0
+hacking_away	hack_away	23.2 26.1 21.1-1	0
+halt	halt	55.4 45.4	2
+hammering	hammer	18.1-1 18.4-1	0
+hand-delivery	handdeliver	11.1	0
+handdelivery	handdeliver	11.1	0
+handle	handle	15.1 98	14
+handling	handle	15.1 98	14
+handwritting	handwrite	25.2 37.11-1 37.7 37.1.1-1-1	1
+hankering	hanker	32.2-1	2
+happening	happen	48.3	1
+happiness	happy	31.1	0
+harassment	harass	31.1	8
+hardening	harden	45.4	0
+harm	harm	31.1	44
+harming	harm	31.1	44
+hating	hate	31.2-1	0
+hatred	hate	31.2-1	0
+hauling	haul	11.4	1
+healing	heal	45.4	19
+heating	heat	45.4 45.3	7
+heightening	heighten	45.4	0
+hemorrhaging	hemorrhage	40.1.3	1
+herding	herd	47.5.2	1
+hesitation	hesitate	53.1	15
+hiding	hide	16-1	7
+highlighting	highlight	41.2.2	0
+hiking	hike	51.3.2	3
+hire	hire	13.5.1 13.5.3	1
+hiring	hire	13.5.1 13.5.3	1
+hissing	hiss	37.3	1
+hit	hit	18.4 18.1-1 17.1-1 47.8-1 40.8.3	7
+hitting	hit	18.4 18.1-1 17.1-1 47.8-1 40.8.3	7
+hold	hold	15.1 49.2 15.2 100.1 15.3	77
+holding	hold	15.1 49.2 15.2 100.1 15.3	77
+holiday	holiday	56	79
+holidaying	holiday	56	79
+hopping	hop	51.3.2-1 47.5.1-1	0
+hosting	host	29.8-1	0
+housing	house	9.10 54.3	128
+humidification	humidify	45.4	0
+humiliation	humiliate	31.1	15
+hunting	hunt	35.1	12
+hurry	hurry	51.3.2-2 53.2	19
+hurting	hurt	31.1 40.8.3-2	0
+hurting	hurt	31.1, 31.3, 40.8.1	0
+hybridization	hybridize	45.4	0
+hydration	hydrate	45.4	1
+hyperextension	hyperextend	45.2	0
+hyperventilating	hyperventilate	47.5.3	1
+hyperventilation	hyperventilate	47.5.3	1
+hypoventilation	hypoventilate	40.1.2	0
+identification	identify	29.2-1-1	7
+illumination	illuminate	25.3	1
+illustration	illustrate	25.3	4
+imagination	imagine	29.2-1-1 29.9-1-1-1	19
+imitation	imitate	101	3
+immersion	immerse	9.1	0
+implantation	implant	9.1	2
+implementation	implement	55.5-1	44
+imposition	impose	63	4
+improvement	improve	45.4	78
+incision	incise	25.1	1
+incorporation	incorporate	22.2-1	1
+increase	increase	45.4	243
+incubation	incubate	45.4	1
+indication	indicate	78-1	63
+induration	indurate	45.4	0
+infection	infect	9.8	26
+inference	infer	97.2 29.5-1	0
+infestation	infest	9.8	1
+inflammation	inflame	31.1	6
+inflation	inflate	45.4	98
+inhalation	inhale	40.1.3-2	0
+inheritance	inherit	13.5.2	2
+initiation	initiate	55.5-1	2
+injection	inject	9.8	19
+injury	injure	40.8.3-2	46
+innovation	innovate	55.5	28
+input	input	37.11	4
+inquiry	inquire	37.1.2	38
+inscription	inscribe	25.1	14
+insertion	insert	9.1-1	1
+insistence	insist	37.7	8
+inspection	inspect	35.4 30.2	54
+inspiration	inspire	27.1-1, 31.1	13
+installation	install	9.1-1 29.1	5
+installment	install	9.1-1 29.1	5
+institution	institute	55.5-1	17
+instruction	instruct	37.9	34
+insulation	insulate	9.9	1
+insult	insult	33.1-1, 31.1	10
+integration	integrate	22.2	24
+intensification	intensify	45.4	2
+intent	intend	61.1 61.2-1-1 62	64
+intention	intend	61.1 61.2-1-1 62	64
+interception	intercept	98	3
+interest	interest	31.1	90
+interesting	interest	31.1	90
+interpolation	interpolate	108-2	0
+interpretation	interpret	29.2	31
+interpreting	interpret	29.2	31
+interrogation	interrogate	37.1.3	10
+intersection	intersect	47.8-1	12
+interspersing	intersperse	22.2-2-1 9.8	0
+interview	interview	37.1.3	148
+intimidation	intimidate	31.1	10
+intonation	intone	26.7-1	1
+intoxication	intoxicate	31.1	2
+introduction	introduce	22.2-3-1 55.5-1	15
+intrusion	intrude	48.1.2	7
+inundation	inundate	9.8	0
+invagination	invaginate	45.4	0
+invention	invent	26.4 26.3-1	11
+inversion	invert	45.4	1
+investigation	investigate	35.4 30.2	31
+investment	invest	13.4.2	406
+invitation	invite	102	59
+involvement	involve	86.2-1 103	48
+irritation	irritate	31.1	4
+isolation	isolate	16 29.10	21
+itching	itch	40.8.1	1
+jab	jab	18.1-1	1
+jeering	jeer	40.2	1
+jogging	jog	51.3.2-2-1	1
+joining	join	22.1-2-1	0
+joining_up	join_up	22.1-2-1	0
+joke	joke	37.6	57
+jolt	jolt	31.1	9
+journey	journey	51.3.2-1	10
+judgement	judge	29.4-1-1-2 29.2 34.2	35
+judgment	judge	29.4-1-1-2 29.2 34.2	35
+justification	justify	37.1.1	28
+kayaking	kayak	51.4.1-1	0
+keeping	keep	15.2 55.6	6
+keeping_up	keep_up	55.6	0
+keratinization	keratinize	45.4	0
+kick	kick	17.1-1-1 18.2 18.1-1 11.4-1-1 23.2 40.3.2	5
+kicking	kick	17.1-1-1 18.2 18.1-1 11.4-1-1 23.2 40.3.2	5
+kidnapping	kidnap	10.5	0
+kill	kill	42.1-1 42.3	52
+killing	kill	42.1-1 42.3	52
+kiss	kiss	36.2 20-1	10
+kissing	kiss	36.2 20-1	10
+kneading	knead	26.5	0
+knifing	knife	18.3 42.2	0
+knitting	knit	26.1	0
+knock	knock	18.1-1 17.1-1 18.4-1	3
+knowledge	know	comprehend-87.2-1         conjecture-29.5-1 consider-29.9-1-1	2
+labeling	label	25.3 9.9	1
+landing	land	9.10-1	19
+laugh	laugh	40.2	120
+laughing	laugh	40.2	120
+launch	launch	55.5-1 17.1-1-1	15
+lead	lead	95.2.2	75
+leadership	lead	95.2.2	75
+leading	lead	95.2.2	75
+leak	leak	43.4	26
+leakage	leak	43.4	26
+leaking	leak	43.4	26
+leap	leap	51.3.2-1	2
+leap	leap	51.3.2-1	2
+leaping	leap	51.3.2-1	2
+leaping	leap	51.3.2-1	2
+learning	learn	14-1 84-1-1	27
+leasing	lease	13.1-1	0
+leasing	lease	13.5.1	0
+lending	lend	13.1	29
+levitation	levitate	45.4	0
+liberation	liberate	10.5	16
+license	license	101	17
+licensing	license	101	17
+lifting	lift	9.4	10
+ligation	ligate	22.3-2-1	0
+liking	like	31.2-1 32.1-1-1	0
+limit	limit	76	145
+limitation	limit	76	145
+lining	line	47.8 9.8	5
+linkage	link	22.1-2-1 22.4	0
+liquidation	liquidate	42.1	0
+listening	listen	30.3 35.5	7
+living	live	47.1-1 46 39.6	60
+loading	load	9.7-2	2
+loan	loan	13.1	57
+lobbying	lobby	58.1	0
+locking	lock	22.4	0
+lodging	lodge	46	3
+logging	log	13.7	0
+look	look	30.3 35.5	145
+looking	look	30.3 35.5	145
+loosening	loosen	45.4	1
+loss	lose	13.2	64
+love	love	31.2-1	121
+lowering	lower	9.4	0
+lubrication	lubricate	9.9	0
+lurking	lurk	47.1-1	0
+maceration	macerate	45.4	0
+magnifying	magnify	45.4	0
+maintenance	maintain	55.6 29.5-2	22
+make	make	26.1-1	34
+make_up	make_up	26.1-1	0
+making	make	26.1-1	34
+manifestation	manifest	48.1.2	11
+manufacturing	manufacture	26.4	4
+march	march	51.3.2-2-1	6
+marginalisation	marginalize	45.7	0
+marginalization	marginalize	45.7	0
+mark	mark	25.1	19
+marking	mark	25.1	19
+marriage	marry	36.2 22.2-3-1-1	75
+massacre	massacre	42.1	15
+massage	massage	20-1	0
+maturation	maturate	45.4	0
+maturity	maturate	45.4	0
+meeting	meet	36.3-1	181
+memorization	memorize	14-2	2
+mentation	mentate	29.9 62	0
+mention	mention	37.7-1	4
+meowing	meow	38	1
+merger	merge	22.1-1-1	47
+merging	merge	22.1-1-1	47
+militarization	militarize	45.7	0
+milling	mill	21.2-2	1
+mining	mine	10.9 35.1	16
+misappropriation	misappropriate	10.5	0
+misdirection	misdirect	51.7	1
+misinterpretation	misinterpret	87.2	0
+misperception	misperceive	30.2 29.2	5
+missing	miss	31.2	0
+mistrust	mistrust	31.2	8
+misunderstanding	misunderstand	87.2	15
+mixing	mix	22.1-1-1 26.3-1	1
+moaning	moan	37.3 40.2	0
+mobilization	mobilize	45.4	5
+mobilizing	mobilize	45.4	5
+model	model	26.4	71
+modeling	model	26.4	71
+moderation	moderate	45.4	7
+modernization	modernize	45.4	9
+modulation	modulate	45.4	0
+moisturization	moisturize	41.1.1	0
+monitoring	monitor	35.4	34
+mopping	mop	10.4.2-1	0
+moralizing	moralize	37.11-1	0
+mourning	mourn	31.3, 31.2	0
+mowing	mow	21.2-2	1
+muffling	muffle	42.3	0
+murder	murder	42.1	67
+murdering	murder	42.1	67
+mutation	mutate	26.6.1	7
+mutilation	mutilate	44	1
+muttering	mutter	37.3	1
+myelosuppression	myelosuppress	16 42.3	0
+nap	nap	40.4	12
+narration	narrate	37.1.1	0
+narrowing	narrow	45.4	7
+nationalization	nationalize	45.4	7
+navigation	navigate	51.4.2	2
+need	need	32.1-1-1 103	206
+neighboring	neighbor	47.8	0
+networking	network	22.1	2
+nomination	nominate	29.1	41
+nonexisting	nonexistent	47.1-1	0
+normalization	normalize	45.4	9
+note	note	30.2	15
+notice	notice	26.7 25.2 37.11 37.7 37.1.1	45
+notification	notify	37.9 37.2	25
+notifying	notify	37.9 37.2	25
+nursing	nurse	29.8-1	6
+oath	oath	13.3 37.13	12
+objection	object	37.8	37
+obliteration	obliterate	44	0
+observation	observe	30.2 35.4	19
+obsession	obsess	31.1, 31.3	15
+occlusion	occlude	45.4	0
+occupation	occupy	31.1	42
+offense	offend	31.1	15
+offer	offer	13.3	129
+offering	offer	13.3	129
+omission	omit	10.1	4
+oozing	ooze	43.4	0
+opacification	opacify	45.4	0
+opening	open	45.4 40.3.2 47.6	43
+opening_up	open_up	45.4	0
+operating	operate	45.4	526
+operation	operate	45.4	526
+opposition	oppose	22.2-3	115
+order	order	13.5.1	122
+ordering	order	13.5.1	122
+ordinance	ordain	29.1	14
+organization	organize	26.4 55.5-1	8
+organizing	organize	26.4 55.5-1	8
+ossification	ossify	45.4	1
+ousting	oust	10.1	1
+outfitting	outfit	13.4.2-1 41.3.3	0
+outrage	outrage	31.1	0
+overestimation	overestimate	54.4	0
+overlap	overlap	22.2-1	2
+overlapping	overlap	22.2-1	2
+overpayment	overpay	68	7
+packaging	package	22.3-2-1	16
+packing	pack	9.7-1-1	2
+painting	paint	24	5
+pairing	pair	22.2-2 22.3-2 22.1-2-1	4
+palpitation	palpitate	40.8.2	0
+pant	pant	40.1.1	0
+parade	parade	51.3.2	8
+paralysis	paralyze	45.4	0
+parching	parch	45.3	0
+partition	partition	23.3	2
+passing_on	pass_on	11.1	0
+patent	patent	101	9
+patrol	patrol	35.2	25
+pawn	pawn	13.1-1	0
+payment	pay	68-1	106
+perception	perceive	30.2	25
+percolation	percolate	45.3 43.4	0
+perfection	perfect	45.4	16
+perforation	perforate	21.2-1	0
+permission	permit	64.3-1, 64.1-1	46
+persistence	persist	47.1-1	0
+perturbation	perturb	31.1	0
+phoning	phone	13.5.1, 37.4.2-1, 37.4.1	1
+photo	photograph	25.4	185
+picketing	picket	35.4	1
+picking	pick	13.5.1	7
+piercing	pierce	19	0
+pioneering	pioneer	29.8-1	0
+pity	pity	31.2	13
+placement	place	9.1-2	9
+plan	plan	62	205
+planning	plan	62	205
+planting	plant	9.7-2 9.1-1 55.5-1	0
+plaquing	plaque	13.5.2 47.5.2	0
+plot	plot	25.2	18
+plugging	plug_up	9.8	0
+plunge	plunge	47.7	2
+poisoning	poison	42.2	14
+poking	poke	19 35.5	0
+polarization	polarize	45.4	4
+policing	police	29.8-1	0
+polish	polish	9.9 10.4.1	4
+pollution	pollute	9.8-1	46
+pooling	pool	22.1-2-1	0
+popping	pop	43.2	0
+popping	pop	45.4	0
+portrayal	portray	29.2-1-1	3
+posing	pose	29.6-2	1
+positioning	position	9.1	3
+post	post	11.1	87
+posting	post	11.1	87
+pounding	pound	18.1-1	0
+pounding	pound	26.1	0
+pouring	pour	9.5 43.4	0
+praise	praise	29.2, 33.1-1-1	27
+preaching	preach	37.11-1 37.1.1	0
+precedence	precede	47.8	4
+preconception	preconceive	29.2-1 97.2	3
+prediction	predict	78	30
+preference	prefer	32.1-1-1 31.2	5
+pregnancy	impregnate	9.8	0
+preoccupation	preoccupy	31.1	5
+preparation	prepare	55.5-1	21
+presentation	present	13.4.1 48.1.2	48
+presenting	present	13.4.1 48.1.2	48
+preservation	preserve	85	8
+pressing	press	12-1-1	0
+presumption	presume	29.5-1	0
+price	price	54.4	1419
+pricing	price	54.4	1419
+printing	print	25.2	7
+procurement	procure	13.5.1	6
+producing	produce	26.4	117
+production	produce	26.4	117
+profession	profess	29.4-1-1-3	1
+progress	progress	45.5	130
+progression	progress	45.5	130
+projection	project	34.2	2
+proliferation	proliferate	45.4	16
+promise	promise	13.3	91
+promotion	promote	102	21
+proof	prove	29.4-1-1 97.2 78-1-1	45
+prophesy	prophesy	29.5-1	0
+proposal	propose	48.1.2 37.7-1 62	43
+proposition	propose	48.1.2 37.7-1 62	43
+prospering	prosper	47.1-1 39.6	0
+prostitution	prostitute	29.8	0
+protection	protect	85	73
+protrusion	protrude	47.6	0
+provision	provide	13.4.1-2	94
+provocation	provoke	31.1, 27.1-1	20
+publication	publish	26.4-1	59
+publishing	publish	26.4-1	59
+puckering	pucker	40.3.2 40.8.2	0
+pull	pull	11.4 23.2 12-1 13.5.1 40.8.3-1-1	1
+pulling	pull	11.4 23.2 12-1 13.5.1 40.8.3-1-1	1
+pulling_out	pull_out	82-1	0
+pulsation	pulsate	47.3	0
+pulse	pulse	47.3	10
+pumping	pump	9.7-1	6
+punch	punch	18.2 21.2-2	0
+punching	punch	18.2 21.2-2	0
+punctuation	punctuate	9.9	1
+purchase	purchase	13.5.2-1	120
+pursuit	pursue	51.6	32
+push	push	23.2 11.4-1-1 12-1-1 9.3-1-1	5
+quadrupling	quadruple	45.4	0
+qualification	qualify	29.6	39
+quarreling	quarrel	36.4	2
+question	question	37.1.3	243
+questioning	question	37.1.3	243
+quotation	quote	37.1.1	63
+quote	quote	37.1.1	63
+radiation	radiate	43.4	37
+rage	rage	47.2	20
+raid	raid	35.4	15
+raise	raise	9.4 40.3.2	19
+raising	raise	9.4 40.3.2	19
+ranking	rank	29.6 29.2	1
+ranting	rant	37.3 37.11-1	2
+rating	rate	54.4 29.1 29.6	56
+ration	ration	13.3	2
+rationing	ration	13.3	2
+re-education	reeducate	37.1.1	0
+re-election	reelect	29.1	18
+readiness	ready	26.3-1	15
+reading	read	14-1 37.1.1-1 54.1-1 84-1-1	26
+reaffirmation	reaffirm	31.2 29.5-2 78-1-1	1
+reapproximation	approximate	34.2 54.4	1
+reasoning	reason	97.2	20
+rebellion	rebel	71	13
+rebuilding	rebuild	26.4	0
+recall	recall	10.2	7
+reception	receive	13.5.2	10
+recertification	recertify	29.2	0
+recirculation	recirculate	47.3	0
+recital	recite	37.1.1	8
+reckoning	reckon	29.9-1 70	0
+recollection	recollect	29.2-1-1	3
+recommendation	recommend	37.7-1-1-1	20
+reconstitution	reconstitute	26.4-1	0
+recording	record	25.4	6
+recruiting	recruit	13.5.3 29.7	22
+recruitment	recruit	13.5.3 29.7	22
+redemption	redeem	10.5	15
+reduction	reduce	76 42.3	41
+reeducation	reeducate	37.1.1	0
+reelection	reelect	29.1	18
+refund	refund	13.1	14
+regard	regard	29.2 30.2	113
+registration	register	101	12
+regret	regret	31.2-1	20
+rehydration	hydrate	45.4	1
+reinjection	inject	9.8	19
+reiteration	reiterate	37.7-1	1
+rejuvenation	rejuvenate	31.1	0
+relaxation	relax	31.1	14
+reliance	rely	70	0
+remaining	remain	47.1-1	0
+remark	remark	37.7-1 37.11-1	31
+remarriage	remarry	22.2-3-1-1	0
+remembering	remember	29.2-1-1 29.9-1-1-1	2
+remembrance	remember	29.2-1-1 29.9-1-1-1	2
+removal	remove	10.1 10.2 10.10	18
+renomination	nominate	29.1	41
+rental	rent	13.5.1	19
+renting	rent	13.5.1	19
+reopening	reopen	45.4	2
+reorganization	reorganize	26.4-1	30
+repayment	pay	68-1	106
+repeat	repeat	26.8 37.7-1 55.4	11
+repetition	repeat	26.8 37.7-1 55.4	11
+reply	reply	37.7	27
+report	report	29.2-1-2 37.7-1 29.9-1	254
+reporting	report	29.2-1-2 37.7-1 29.9-1	254
+representation	representation	29.2-1-1	0
+reproduction	reproduce	45.4	3
+request	request	58.2	86
+requirement	require	103	155
+rescue	rescue	10.5	43
+reservation	reserve	13.5.1	18
+residence	reside	46 47.1-1	16
+resonance	resonate	47.4	4
+resort	resort	26.6.2	10
+respect	respect	31.2	70
+responding	respond	37.7	163
+response	respond	37.7	163
+rest	rest	47.6	21
+resting	rest	47.6	21
+restitution	restore	13.2	11
+restoration	restore	13.2	11
+restraint	restrain	76	2
+restriction	restrict	76	96
+resumption	resume	55.1-1	14
+retaliation	retaliate	71	19
+retirement	retire	82-3 10.11	41
+retracting	retract	10.1	0
+retraction	retract	10.1	0
+retrieval	retrieve	13.5.2	1
+revelation	reveal	78-1-1 37.10 48.1.2 29.2-1-2 37.7-1	13
+reversal	reverse	45.4	23
+reverse	reverse	45.4	23
+reversion	revert	26.6.2	5
+revitalization	revitalize	31.1	0
+revival	revive	45.4	0
+ride	ride	51.4.2	51
+riding	ride	51.4.2	51
+ring	ring	43.2	3
+ringing	ring	43.2	3
+ripening	ripen	45.4	0
+ripple	ripple	47.2 9.8	1
+rise	rise	47.6 50 51.1	92
+risk	risk	94-1	77
+roll	roll	51.3.1 9.6 51.3.2-2 40.3.2 22.3-2 11.2-1 26.3-1 23.2 43.2 26.1 45.2 47.4	12
+rolling	roll	51.3.1 9.6 51.3.2-2 40.3.2 22.3-2 11.2-1 26.3-1 23.2 43.2 26.1 45.2 47.4	12
+rotation	rotate	47.3 9.6 51.3.1	9
+rowing	row	51.4.2 11.5	0
+rubbing	rub	40.3.2 9.7-1 20-1 10.4.1-1	0
+ruin	ruin	44	1
+run_up	run_up	47.7	0
+rush	rush	51.3.2-2-1	21
+sacking	sack	10.10	0
+sacrifice	sacrifice	13.2-1-1	9
+sailing	sail	51.4.2	1
+sale	sell	13.1-1	289
+salivation	salivate	40.1.1	0
+salutation	salute	40.3.3	0
+salvage	salvage	10.5-1	2
+satiation	satiate	31.1	0
+satisfaction	satisfy	31.1	19
+saturation	saturate	9.8	0
+saving	save	13.5.1-1	0
+saving	save	13.5.1-1 54.5	0
+scalloping	scallop	45.3	0
+scanning	scan	35.4 30.2	2
+scare	scare	31.1	2
+scaring	scare	31.1	2
+scarring	scar	25.1	0
+scattering	scatter	9.7-1	0
+scheduling	schedule	26.4-1	1
+schmoozing	schmooze	37.6	0
+scooping	scoop	9.3	1
+scratching	scratch	18.2 40.8.3-2 21.1-1 10.4.1-1	1
+scream	scream	37.3	4
+scruple	scruple	53.1-1	0
+sculpting	sculpt	26.1-1	1
+search	search	35.2	58
+searching	search	35.2	58
+seasoning	season	9.8	0
+seclusion	seclude	16	1
+seeding	seed	9.9 9.7-1	0
+seeking	seek	35.1	12
+segregation	segregate	23.1-1 23.3	5
+selection	select	13.5.2 29.2	64
+selling	sell	13.1-1	289
+sensation	sense	30.1-1	78
+sense	sense	30.1-1	78
+sensing	sense	30.1-1	78
+separation	separate	23.1-2 10.1 29.10	21
+sequestering	sequester	16 10.5	1
+service	serve	29.6-2 104	300
+serving	serve	29.6-2 104	300
+serving_up	serve_up	13.4.1-1	0
+setting	set	9.1-2 41.2.2 25.1	10
+shading	shade	85	0
+shadowing	shadow	51.6	0
+shaking	shake	31.1 47.3 40.6 40.3.2 9.3-1-1 26.5	1
+shame	shame	31.1	45
+shaming	shame	31.1	45
+shape	shape	26.1-1 48.1.2	16
+shaving	shave	41.2.1 41.1.1 10.4.1	1
+shearing	shear	10.4.2-1	0
+shedding	shed	43.4	1
+shift	shift	11.1 26.6.2	31
+shifting	shift	11.1 26.6.2	31
+shipbuilding	shipbuilding	26.1-1	2
+shipping	ship	11.1-1	29
+shock	shock	31.1	23
+shoot	shoot	42.2	29
+shooting	shoot	42.2	29
+shopping	shop	35.2	25
+shortening	shorten	45.4	0
+shower	shower	41.1.1 17.2 9.7-1 57	22
+showing_off	show_off	48.1.2	0
+shunting	shunt	11.1	0
+sight	see	29.2-1 30.1-1 29.9-1-1	22
+signing_up	sign_up	13.5.3	0
+simulation	simulate	55.5-1	12
+singing	sing	37.3 43.2	6
+sink	sink	45.4	4
+sinking	sink	45.4	4
+sitting	sit	47.6 50	3
+skateboarding	skateboard	51.4.1-1	0
+skiing	ski	51.4.1-1	11
+skimming	skim	10.4.1	0
+skirmish	skirmish	36.4-1	0
+slash	slash	21.1-1	4
+slaughter	slaughter	42.1 13.5.1	4
+slaying	slay	42.1	0
+sleeping	sleep	40.4	10
+slide	slide	51.3.2-2 11.2-1 51.3.1	6
+slowing	slow	45.4	4
+smack	smack	40.3.2	0
+smashing	smash	18.1-1 45.1 21.2-1 17.1-1	0
+smashing	smash	18.4-1	0
+smell	smell	30.1 35.3	23
+smuggling	smuggle	11.1-1 10.5-1	0
+snacking	snack	39.5	0
+sneezing	sneeze	40.2 40.1.1	0
+snoring	snore	40.1.1 40.2	1
+soaking	soak	9.8 10.4.1 45.4	1
+sobbing	sob	40.2	1
+softening	soften	45.4	0
+soiling	soil	9.8	0
+solution	solve	84	33
+solving	solve	84	33
+sound	sound	43.2 47.4	50
+sowing	sow	9.7-1	0
+span	span	47.8	9
+speaking	speak	37.5 37.11-1	139
+specification	specify	29.2	20
+speculating	speculate	29.5-1	89
+speculation	speculate	29.5-1	89
+speech	speak	37.5 37.11-1	139
+speeding	speed	51.3.2-2	4
+spelling	spell	25.2	8
+spending	spend	68	129
+spitting	spit	40.1.2	0
+splaying	splay	45.2	0
+split	split	23.2	12
+splitting	split	23.2	12
+spotting	spot	30.2	0
+spotting	spot	9.8	0
+spraying	spray	9.7-1	1
+spying	spy	30.2	3
+squeeze	squeeze	20-1 12-1-1 26.5	5
+squeezing	squeeze	20-1 12-1-1 26.5	5
+squinting	squint	30.3	0
+stab	stab	42.2 19 18.2	4
+stabbing	stab	42.2 19 18.2	4
+stabilization	stabilize	45.4	13
+stagflation	inflate	45.4	98
+staging	stage	55.5 26.4	2
+stagnation	stagnate	45.5	7
+staining	stain	24 9.9 9.8-1	0
+stalking	stalk	35.3	2
+stall	stall	53.1-1	1
+staring	stare	30.3	0
+start	start	55.1-1	69
+starting	start	55.1-1	69
+starvation	starve	40.7	10
+statement	state	37.7-1	209
+stay	stay	46 47.1-1	23
+steering	steer	51.7	2
+step	step	51.3.2	70
+sterilization	sterilize	45.4	3
+stiffening	stiffen	45.4	0
+stimulation	stimulate	31.1	5
+stocking	stock	9.7-2 15.2	2
+stop	stop	55.4-1	18
+stoppage	stop	55.4-1	18
+storage	store	15.2	45
+straining	strain	40.8.3-2	0
+stratification	stratify	45.4	1
+stream	stream	48.1.1	20
+strengthening	strengthen	45.4	14
+stressing	stress	9.9	0
+stretching	stretch	47.7 45.2 40.3.2	0
+stride	stride	51.3.2-1	8
+stripping	strip	41.1.1 10.4.1-1	0
+stroke	stroke	20 25.2	8
+stroll	stroll	51.3.2-1	1
+struggle	struggle	36.4-1	18
+struggling	struggle	36.4-1	18
+study	study	14-1 30.2 34.1 84-1-1	162
+studying	study	14-1 30.2 34.1 84-1-1	162
+stuttering	stutter	37.3	0
+success	succeed	74-1	108
+suction	suction	10.4.1-1	0
+suffering	suffer	31.3	7
+suggestion	suggest	37.7-1-1	58
+supersaturation	supersaturate	45.4	0
+supply	supply	13.4.1-1	43
+support	support	31.2 47.8	283
+supposition	suppose	29.9-2	1
+suppression	suppress	42.3 16	11
+surprise	surprise	31.1	33
+surrender	surrender	13.2-1-1	4
+surrounding	surround	9.8	0
+surveilance	surveil	30.2 35.4	0
+survey	survey	35.4 30.2	76
+survival	survive	39.6	41
+suspension	suspension	10.10	0
+suspicion	suspect	29.9-2 81 29.5-1	17
+suturing	suture	22.4	0
+swallowing	swallow	39.3-2 40.1.1	0
+swat	swat	18.2	1
+sweating	sweat	40.1.2 43.4	2
+swelling	swell	45.5	2
+swim	swim	51.3.2 47.5.1	13
+swimming	swim	51.3.2 47.5.1	13
+switch	switch	26.6.2-1	8
+switching	switch	26.6.2-1	8
+tackle	tackle	98	1
+tag	tag	9.9 25.3	3
+takeover	take_over	93	0
+taking_on	take_on	93	0
+taking_on	take_on	98	0
+taking_over	take_over	93	0
+talk	talk	37.5 37.11-1	300
+talking	talk	37.5 37.11-1	300
+tanning	tan	45.4	1
+tapering_off	taper_off	45.4	0
+tapping	tap	18.1-1 17.1-1	1
+tariff	tax	54.5	34
+taste	taste	30.1 35.3	24
+tasting	taste	30.1 35.3	24
+tattooing	tattoo	25.1	0
+taxation	tax	54.5	34
+teaching	teach	37.1.1-1-1	9
+tearing	tear	23.2 45.1 40.8.3-1-1	0
+tearing	tear	51.3.2	0
+teasing	tease	31.1	2
+teething	teethe	39.2-1	0
+telling	tell	37.1.1-1-1	2
+temptation	tempt	31.1	23
+tension	tense	45.4	9
+termination	terminate	10.10	2
+termination	terminate	55.4	2
+terror	terrorism	31.1	0
+terrorising	terrorize	31.1	64
+terrorizing	terrorize	31.1	64
+test	test	35.4	328
+testimony	testify	37.11-1	63
+testing	test	35.4	328
+thawing	thaw	45.4	0
+theft	thieve	10.5	0
+thickening	thicken	45.4	3
+thieving	thieve	10.5	0
+thinking	think	29.9-2 62	135
+thinning	thin	45.4	0
+thought	think	29.9-2 62	135
+threat	threaten	31.1	0
+thrill	thrill	31.1	1
+throw	throw	17.1-1-1	10
+throwing	throw	17.1-1-1	10
+thrust	thrust	12-1-1 11.4-1-1	3
+thumping	thump	18.4-1 18.1 18.3	0
+thumping	thump	43.2	0
+tickling	tickle	20-1 31.1 40.8.2	0
+tightening	tighten	45.4	3
+tiling	tile	9.8 9.9	0
+tingling	tingle	40.8.2	0
+tiptoeing	tiptoe	51.3.2	0
+tolerance	tolerate	31.2	25
+torture	torture	31.1	35
+toss	toss	17.1-1-1 26.3-1 40.3.2	4
+tossing	toss	17.1-1-1 26.3-1 40.3.2	4
+touch	touch	20-1 86.2-1 47.8-1 31.1	35
+touching	touch	20-1 86.2-1 47.8-1 31.1	35
+touching_on	touch_on	86.2-1	0
+tow	tow	11.4	2
+towing	tow	11.4	2
+tracing	trace	25.2	0
+track	track	35.3 51.6	18
+tracking	track	35.3 51.6	18
+training	train	13.5.3	85
+transcription	transcribe	25.4	1
+transfer	transfer	11.1 13.2-2	45
+transformation	transform	26.6.1	26
+translation	translate	26.6.1	20
+transmission	transmit	11.1-1	12
+transmutation	transmute	26.6.1	1
+transport	transport	11.1	123
+transportation	transport	11.1	123
+trapping	trap	9.10	0
+travel	travel	51.3.2-1	56
+traveling	travel	51.3.2-1	56
+travelling	travel	51.3.2-1	56
+tunneling	tunnel	35.5-1	0
+turn	turn	51.3.1 40.3.2 40.8.3-1-1 47.7	24
+turnabout	turnabout	40.3.2 40.8.3 51.3.1 47.7	1
+turning	turn	51.3.1 40.3.2 40.8.3-1-1 47.7	24
+tutoring	tutor	29.8-1	1
+twist	twist	9.6-1 26.5	16
+twitching	twitch	40.3.2	0
+typing	type	25.4 25.2	2
+typing_up	type_up	25.2 25.4	0
+ulceration	ulcerate	45.4	0
+ultrafiltration	ultrafilter	45.4	0
+underestimation	underestimate	29.2-1	0
+understanding	understand	accept-77.1 comprehend-87.2-1	47
+undertaking	undertake	98 55.1	2
+undoing	undo	44	1
+unification	unify	22.2	74
+union	union	45.4	0
+unloading	unload	10.4.1	1
+upgrade	upgrade	29.1	11
+urbanization	urbanize	45.4	0
+urging	urge	58.1	1
+urination	urinate	40.1.2-1 40.1.3-1	1
+use	use	66, 105.1, 39.1-3	259
+using	use	66, 105.1, 39.1-3	259
+vacation	vacation	56	72
+vacuuming	vacuum	10.4.2-1	0
+valuation	value	54.4	5
+variation	vary	23.4 45.4	25
+vault	vault	51.3.2-1	0
+ventilation	ventilate	45.4	7
+verification	verify	101 37.1.1 78-1-1	6
+vexation	vex	31.1	0
+vibration	vibrate	47.3 45.4	6
+view	view	29.2-1 29.9-1	364
+visit	visit	36.3-1	48
+visit	visit	36.3-1	48
+visiting	visit	36.3-1	48
+visualization	visualize	29.2-1-1	4
+vocalization	vocalize	37.7	0
+voice	voice	37.7	208
+volunteering	volunteer	29.8 37.7	1
+vomiting	vomit	40.1.2	4
+voyage	voyage	51.4.2	0
+waiting	wait	47.1-1	9
+walk	walk	51.3.2	25
+walking	walk	51.3.2	25
+war	war	36.4-1	550
+warfare	war	36.4-1	550
+warming	warm	45.4	68
+warning	warn	37.9-1	40
+washing	wash	10.4.1-1 26.3-2 41.2.1 41.1.1	6
+waste	waste	66-1 44 68	38
+wasting	waste	66-1 44 68	38
+watch	watch	35.2 30.2	13
+watching	watch	35.2 30.2	13
+watering	water	9.9	1
+waxing	wax	9.9 41.2.2	1
+weakening	weaken	45.4	4
+wedding	wed	22.2-3-1-1	71
+weeping	weep	40.2 40.1.2	5
+westernization	westernize	45.4	2
+wetting	wet	45.4	0
+whack	whack	18.1	1
+wheezing	wheeze	43.2 40.1.1	0
+whining	whine	37.8 38 37.3 43.2	1
+whooshing	whoosh	43.2	1
+widening	widen	45.4	5
+win	win	13.5.1	23
+winning	win	13.5.1	23
+wish	wish	62 32.2-1	29
+withdrawal	withdraw	10.1 82-3 10.11 51.1	26
+wreck	wreck	44	8
+wrestling	wrestle	36.4-1	5
+wringing	wring	40.3.2 20-1	1
+write	write	37.1.1-1-1 37.11-1 25.2 37.7	42
+writing	write	37.1.1-1-1 37.11-1 25.2 37.7	42
+yapping	yap	38 37.3	1
+yawning	yawn	40.1.1 40.2	0
+yelling	yell	38 37.3	1
+yellowing	yellow	45.4	0

--- a/semparse-core/src/main/resources/mappings/nominal-mappings.tsv
+++ b/semparse-core/src/main/resources/mappings/nominal-mappings.tsv
@@ -1,0 +1,1922 @@
+abbreviation	abbreviate	45.4
+abdication	abdicate	10.11
+abduction	abduct	10.5
+ablation	ablate	10.1
+abolition	abolish	10.1
+abrasion	abrade	45.4
+absolution	absolve	80-1
+abstention	abstain	69
+abstraction	abstract	10.1
+abuse	abuse	33
+acceleration	accelerate	45.4
+acceptance	accept	29.2-1-1 77.1 13.5.2
+acclaim	acclaim	33
+accommodation	accommodate	26.9
+accompaniment	accompany	51.7
+accumulation	accumulate	47.5.2 13.5.2
+accusation	accuse	81
+achievement	achieve	55.2
+aching	ache	40.8.2
+acknowledgment	acknowledge	37.10 29.9-1
+acquisition	acquire	13.5.2-1
+acquittal	acquit	80-1
+acting	act	29.6-1
+activating	activate	45.4
+activation	activate	45.4
+adaptation	adapt	26.9
+adaption	adapt	26.9
+addiction	addict	96
+addition	add	22.1-2 108
+addressing	address	25.3
+adhesion	adhere	22.5
+adjustment	adjust	26.9
+administration	administer	13.2-1-1
+admiration	admire	31.2
+admission	admit	37.10 29.5-2
+admission	admit	65
+admitting	admit	37.10 29.5-2
+admitting	admit	65
+admonition	admonish	37.9-1 58.1
+adoption	adopt	93 29.2 29.1
+advance	advance	45.6-1 102 51.1-2 45.4
+advertisement	advertise	35.2
+advertising	advertise	35.2
+advice	advise	37.9-1 37.2 37.7-1 58.1
+affiliation	affiliate	22.2-2
+affirmation	affirm	31.2 29.5-2 78-1-1
+affliction	afflict	31.1
+agglomeration	agglomerate	45.4
+aggravation	aggravate	31.1
+aggregation	aggregate	47.5.2
+aging	age	45.4
+agitation	agitate	31.1
+agreement	agree	36.1-1
+aid	aid	72-1
+aim	aim	intend-61.2 wish-62
+airing	air	45.4
+alert	alert	37.9
+alienation	alienate	31.1
+allegation	allege	37.7
+alleviation	alleviate	80
+alliance	ally	71
+allocation	allocate	13.3
+allotment	allot	13.3
+allowance	allow	13.3-1
+allowance	allow	64.3 64.1-1
+alteration	alter	26.6.1 45.4
+alternation	alternate	22.2-2-1 86.1
+amalgamation	amalgamate	22.1-1-1 22.2-1-1
+ambulation	ambulate	51.3.2
+amplification	amplify	37.12 45.4
+amusement	amuse	31.1
+analysis	analyze	34.1
+analyze	analyze	34.1
+animation	animate	45.4
+annexation	annex	10.5
+annihilation	annihilate	44 42.1
+annnunciation	announce	37.7-1 48.1.2
+annotation	annotate	25.1
+announcement	announce	37.7-1 48.1.2
+announcing	announce	37.7-1 48.1.2
+appeal	appeal	31.4-3
+appearance	appear	48.1.1
+application	apply	105.1
+appointment	appoint	29.1
+appraisal	appraise	54.4
+appreciation	appreciate	31.2
+approach	approach	51.1-1
+approach	approach	98
+appropriating	appropriate	13.5.2
+appropriation	appropriate	13.5.2
+approval	approve	33 31.3-6 64
+approximation	approximate	34.2 54.4
+argument	argue	37.6 36.4-1 36.1-1-1
+arrangement	arrange	26.1 55.5-1 9.1
+arrival	arrive	51.1
+articulation	articulate	37.7-1
+ascending	ascend	47.7 51.1-3
+ascension	ascend	47.7 51.1-3
+ascent	ascend	47.7 51.1-3
+asphyxiation	asphyxiate	42.2 40.7
+assassination	assassinate	42.1
+assault	assault	33
+assembly	assemble	26.1
+assembly	assemble	47.5.2
+assertion	assert	29.5
+assessment	assess	34.2 34.1 54.4
+assignment	assign	13.3
+assimilation	assimilate	14-2-1 26.9
+assistance	assist	72-1
+association	associate	amalgamate-22.2-2
+assumption	assume	93
+assurance	assure	99 37.13 37.9
+attack	attack	33
+attacking	attack	33
+attainment	attain	13.5.1
+attempt	attempt	61
+attenuation	attenuate	45.4
+audit	audit	34.1
+augmentation	augment	45.4
+average	average	108-3
+averaging	average	108-3
+awakening	wake	45.4
+award	award	13.3
+baking	bake	26.1 26.3-1 45.3
+banding	band	22.4 22.3-2
+banging	bang	18.4-1 18.1
+banging	bang	43.2
+banking	bank	9.10
+banning	ban	67
+bargain	bargain	36.1 89
+bargaining	bargain	36.1 89
+barter	barter	13.6
+bashing	bash	18.4-1 18.1
+basking	bask	31.3-5
+bath	bathe	9.8 41.1.1
+bathing	bathe	9.8 41.1.1
+battering	batter	18.1-1
+batting	bat	40.3.2
+battle	battle	36.3-2 36.4-1
+bearing	bear	31.2
+bearing	bear	86.2-1
+beating	beat	18.1-1
+bedding	bed	9.10
+bedwetting	bedwet	45.4
+beginning	begin	55.1-1
+beheading	behead	42.2
+being	be	109-1-1
+belching	belch	40.1.1
+belittling	belittle	33
+bend	bend	47.6 47.7 50 26.5 45.2
+bending	bend	47.6 47.7 50 26.5 45.2
+bequest	bequeath	13.3
+bet	bet	70 94 54.5
+betting	bet	70 94 54.5
+bias	bias	96
+bickering	bicker	36.4-1
+bifurcation	bifurcate	45.4
+biking	bike	11.5 51.4.1-1
+billing	bill	54.5
+binding	bind	9.8 22.3-2-1
+bite	bite	40.8.3-2 18.2
+biting	bite	40.8.3-2 18.2
+blame	blame	33
+blanking	blanking	10.4.1
+blast	blast	43.2
+blaze	blaze	43.1
+bleeding	bleed	40.1.2 43.4-1
+blessing	bless	33
+blistering	blister	45.5
+blitz	blitz	44
+block	block	67 9.8 16
+blockade	blockade	9.8
+blockage	block	67 9.8 16
+blocking	block	67 9.8 16
+bloom	bloom	45.5 47.2
+blooming	bloom	45.5 47.2
+blossoming	blossom	47.2
+blow	blow	23.2
+blowing	blow	23.2
+blowing	blow	26.1
+blowing_up	blow_up	23.2
+blunting	blunt	45.4
+blurring	blur	45.4
+boarding	board	46
+boast	boast	37.8
+boating	boat	51.4.1
+boil	boil	26.3-2 45.3
+bombardment	bombard	9.8
+bond	bond	shake-22.3-2-1 tape-22.4
+bonding	bond	shake-22.3-2-1 tape-22.4
+boost	boost	102
+borrowing	borrow	13.5.2
+botching	botch	45.4
+bounce	bounce	51.3.2-2 11.2-1 51.3.1
+bow	bow	40.3.3 95
+bow	bow	47.3 47.6 50
+bowling	bowl	51.3.2-2
+boxing	box	9.10
+boxing	box	36.3-2
+boycott	boycott	52
+brawl	brawl	36.4-1
+brawling	brawl	36.4-1
+break	break	23.2 40.8.3-1-1 45.1
+break	break	48.1.1
+break_up	break_up	45.1
+breakdown	break_down	45.1
+breaking	break	23.2 40.8.3-1-1 45.1
+breaking_off	break_off	23.2
+breakup	break_up	45.1
+breastfeeding	breastfeed	39.7
+breath	breathe	40.1.2-1
+breathing	breathe	40.1.2-1
+briefing	brief	37.9
+broadcast	broadcast	37.4
+broadening	broaden	45.4
+bruising	bruise	40.8.3-2 21.2-1
+brushing	brush	41.2.1 41.2.2 10.4.2-1
+budding	bud	45.5
+build	build	26.1-1
+building	build	26.1-1
+bulging	bulge	47.5.3 47.2
+bullying	bully	59-1 29.8-1
+burden	burden	13.4.2-1-1
+burial	bury	9.1-1
+burn	burn	45.5 40.8.3-2 43.1 45.4
+burning	burn	45.5 40.8.3-2 43.1 45.4
+burping	burp	40.1.1
+burst	burst	45.4
+burst	burst	48.1.1
+buying	buy	13.5.1
+buyout	buy_out	13.5.1
+calcification	calcify	45.4
+calcifying	calcify	45.4
+call	call	13.5.1
+call	call	37.3
+call	call	60
+calling	call	13.5.1
+calling	call	29.3
+calling	call	37.3
+calling	call	60
+calving	calve	28
+camping	camp	46
+cancerization	cancerize	45.4
+canning	can	10.10
+cap	cap	9.9
+capitulation	capitulate	95
+capture	capture	10.5-1
+care	care	31.3
+caring	care	31.3
+cascading	cascade	47.7
+cast	cast	17.1
+casting	cast	26.1
+castration	castrate	45.4
+catalog	catalogue	29.10
+catalogue	catalogue	29.10
+catch	catch	13.5.1
+catching	catch	13.5.1
+categorization	categorize	29.10 45.4
+causation	cause	27.1-1, 27.2
+caution	caution	37.9-1
+celebration	celebrate	33
+certification	certify	29.2
+cessation	cease	55.4-1
+championing	champion	29.8-1
+championship	champion	29.8-1
+chance	chance	94-1
+change	change	26.6.1-1 45.4
+changing	change	26.6.1-1 45.4
+characterization	characterize	29.2-1
+charge	charge	51.3.2
+charge	charge	54.5
+chase	chase	51.6
+chasing	chase	51.6
+chat	chat	37.6
+chatting	chat	37.6
+cheating	cheat	10.6
+check	check	35.2
+check_up	check_up	35.2
+checking	check	35.2
+chemoprevention	chemoprevent	67
+chewing	chew	39.2-1
+chlorination	chlorinate	45.4
+choice	choose	13.5.1
+choking	choke	40.7
+choosing	choose	13.5.1
+chop	chop	21.2-2 21.1-1 18.2
+christening	christen	29.3
+circularisation	circularize	13.2-1-1
+circumcision	circumcise	45.4
+civilization	civilize	45.4
+claim	claim	37.7-1
+clapping	clap	40.3.1-1 43.2
+clarification	clarify	45.4
+clash	clash	18.4-1 43.2
+clash	clash	36.4-1
+classification	classify	29.2 29.10
+cleaning	clean	10.3 26.3-2 45.4
+cleaning	clean_up	10.3 26.3-2 45.4
+cleansing	cleanse	10.6
+clearance	clear	80-1 26.3-1 10.3-1 45.4
+clearing	clear	80-1 26.3-1 10.3-1 45.4
+cleavage	cleave	21.2-1
+clenching	clench	40.3.2
+click	click	40.3.2 43.2 18.1
+climb	climb	47.7-1, 45.6.1-1
+climb	climb	51.3.2, 51.1-1-3
+climbing	climb	47.7-1, 45.6.1-1
+climbing	climb	51.3.2, 51.1-1-3
+clip	clip	41.2.2 21.1-1
+clogging	clog	9.8 45.4
+close	close	40.3.2 45.4
+closing	close	40.3.2 45.4
+closing	close	45.4
+clothing	clothe	41.1.1
+clouding	cloud	45.4
+clubbing	club	18.3
+clubbing	clubbing	47.3 26.7
+clunking	clunk	43.2
+co-existence	coexist	36.1 47.1-1
+coagulation	coagulate	45.4
+coating	coat	9.8
+coblation	ablate	10.1
+coding	code	29.10
+coercion	coerce	59
+coexistence	coexist	36.1 47.1-1
+cohesion	cohere	89
+collaborating	collaborate	36.1 73-1 71
+collaboration	collaborate	36.1 73-1 71
+collapse	collapse	45.4
+collecting	collect	22.3-2 47.5.2 13.5.2 26.5 45.4
+collection	collect	22.3-2 47.5.2 13.5.2 26.5 45.4
+collision	collide	36.1 18.4-1 18.4
+collusion	collude	71
+coloration	color	24
+coloring	color	24
+combat	combat	36.4-1
+combination	combine	22.1-1-1
+combustion	combust	45.4
+coming	come	51.1
+commendation	commend	33
+comment	comment	37.11-1-1
+commentary	comment	37.11-1-1
+commercialization	commercialize	45.4
+commissioning	commission	59
+commitment	commit	79 92-1
+communicating	communicate	36.1 36.4-1 37.1.1
+communication	communicate	36.1 36.4-1 37.1.1
+comparison	compare	22.2-2
+compensation	compensate	33 13.4.2-1-1
+competition	compete	36.4-1
+compilation	compile	26.1
+complaining	complain	37.8
+complaint	complain	37.8
+completion	complete	55.2
+composition	compose	26.4
+composition	compose	26.7-2 26.4
+comprehension	comprehend	87.2-1
+compression	compress	26.5
+compromise	compromise	36.1
+compulsion	compel	59
+computation	compute	26.4
+con	con	59-1 10.6-1
+concentration	concentrate	focus-87.1
+concern	concern	31.1
+concession	concede	13.3
+conclusion	conclude	55.4-1
+conclusion	conclude	97.2
+condemnation	condemn	33 81
+condensation	condense	45.4
+conditioning	condition	41.2.2
+conduct	conduct	51.7
+confederation	confederate	22.2-2
+conference	confer	36.1 37.6
+confession	confess	37.10 37.7-1
+confirmation	confirm	29.5-2 78-1-1
+confiscation	confiscate	10.5
+conflict	conflict	36.4-1
+confrontation	confront	98
+confusion	confuse	amalgamate-22.2-2 amuse-31.1
+conglomeration	combine	22.1-1-1
+congratulation	congratulate	33
+congregation	congregate	47.5.2
+conization	conization	10.1
+connecting	connect	22.4 22.1-2-1
+connection	connect	22.4 22.1-2-1
+conquering	conquer	42.3
+conquest	conquer	42.3
+conservation	conserve	13.5.1
+consideration	consider	29.9-1-1-1
+consolation	console	31.1
+consolidation	consolidate	22.2-2-1 22.2-1-1 22.1-1
+conspiracy	conspire	71
+constitution	constitute	55.5
+construction	construct	26.4 45.4
+consult	consult	37.1.2 36.3-1 36.4
+consultation	consult	37.1.2 36.3-1 36.4
+consulting	consult	37.1.2 36.3-1 36.4
+consuming	consume	39.4-1 66
+consumption	consume	39.4-1 66
+containment	contain	47.8 54.3
+contamination	contaminate	9.8
+content	content	31.1
+contention	contend	36.4
+continuation	continue	55.6 55.3
+contracting	contract	45.4
+contracting	contract	89 13.5.3
+contraction	contract	45.4
+contrast	contrast	22.2-2-1
+contribution	contribute	13.2-1-1
+convening	convene	47.5.2
+convention	convene	47.5.2
+convergence	converge	47.7 87.1
+conversation	converse	37.6
+conversion	convert	26.6.1-1 26.6.2-1
+conveyancing	conveyancing	11.1
+convulsion	convulse	40.6
+cooking	cook	26.1 26.3-1 45.3
+cooling	cool	45.4
+cooperation	cooperate	36.1 73-1
+coping	cope	83-1
+copy	copy	25.2 25.4
+copying	copy	25.2 25.4
+correction	correct	45.4
+correlation	correlate	22.2-2-1 86.1
+corrosion	corrode	45.5 45.4
+corruption	corrupt	45.4
+cost	cost	54.2
+cough	cough	40.1.2-1
+coughing	cough	40.1.2-1
+counseling	counsel	37.9-1
+count	count	34.2 108
+counting	count	34.2 108
+coupling	couple	22.2-1
+coverage	coverage	9.8 47.8
+covering	cover	9.8 47.8
+crabbing	crab	13.7
+crack	crack	43.2
+crack	crack	61
+cracking	crack	18.4-1 18.3
+cracking	crack	43.2
+cracking	crack	45.1
+crash	crash	18.4-1 43.2 45.1
+craving	crave	32.1 32.2-1
+creation	create	26.4, 27.1
+credit	credit	13.4.1-1
+crepitation	crepitate	43.2
+criticism	criticize	33
+criticizing	criticize	33
+crossing	cross	47.8-1, 40.3.2
+crossing	cross	51.1-1-3, 47.7
+crossing_out	cross_out	40.3.2
+crushing	crush	31.1 42.3 45.1 21.2-1
+crusting	crust	45.5
+cry	cry	37.3
+crying	cry	31.3-3 40.1.2-1 40.2 43.2
+crying	cry	37.3
+crying_out	cry_out	37.3
+cuddling	cuddle	36.2
+cultivation	cultivate	26.3-1
+curb	curb	42.3
+cure	cure	10.6 80-1
+cut	cut	31.1 41.2.2 26.1-1 21.1-1 40.8.3-2 47.7 23.2
+cutting	cut	31.1 41.2.2 26.1-1 21.1-1 40.8.3-2 47.7 23.2
+cycling	cycle	51.4.1-1
+damage	damage	44
+dampening	dampen	42.3
+dampening	dampen	45.4
+dance	dance	26.7-1-1 51.5
+dance	dance	47.3
+dancing	dance	26.7-1-1 51.5
+darkening	darken	45.4
+dating	date	25.3
+dating	date	36.2
+dawn	dawn	48.1.1
+dazzling	dazzle	31.1
+deal	deal	13.1
+deal	deal	83
+dealing	deal	13.1
+dealing	deal	83
+death	die	48.2
+debate	debate	37.6 36.3-2 36.1-1-1
+debriefing	debrief	37.9
+deceleration	decelerate	45.4
+deception	deceive	59-1
+decision	decide	13.5.1
+declaration	declare	37.7-1 48.1.2
+decline	decline	45.6-1
+decomposition	decompose	45.5
+decompression	decompress	45.4
+deconditioning	decondition	41.2.2
+decoration	decorate	9.8 25.3
+decrease	decrease	45.6-1 45.4
+dedication	dedicate	79
+deduction	deduct	10.1 108-2
+deepening	deepen	45.4
+defamation	defame	33
+defecation	defecate	40.1.2-1
+defence	defend	85
+defense	defend	85
+definition	define	29.2-1-1 48.1.2
+deflation	deflate	45.4
+deforestation	deforest	10.8
+deformation	deform	26.6.1
+degeneration	degenerate	45.4
+degradation	degrade	45.4
+dehydration	dehydrate	45.4
+delay	delay	53.1-1
+deleting	delete	10.1
+deletion	delete	10.1
+deliberation	deliberate	36.1 36.3-1
+delivery	deliver	11.1
+delusion	delude	59-1
+demand	demand	103 60-1
+demolition	demolish	44 31.1
+demonstration	demonstrate	37.1.1 78-1-1
+demoralization	demoralize	31.1
+dent	dent	21.2-1
+denunciation	denounce	33
+departure	depart	10.11 51.1-1
+dependency	depend	70
+depiction	depict	29.2
+depletion	deplete	10.6
+deportation	deport	10.2
+deposit	deposit	9.1-1
+deposition	deposit	9.1-1
+depreciation	depreciate	45.6-1
+depression	depress	31.1
+deprivation	deprive	10.6
+derision	deride	33
+derivation	derive	97.2 48.1.1 26.4
+desalination	desalinate	45.4
+desalinization	desalinate	45.4
+desaturation	desaturate.	45.4
+descending	descend	47.7 51.1-3
+description	describe	29.2-1-1
+desecration	desecrate	44
+design	design	26.4-1
+designation	designate	29.1
+desire	desire	32.1
+destabilization	destabilize	45.4
+destruction	destroy	44
+detachment	detach	23.3
+detection	detect	30.1-1
+deterioration	deteriorate	45.5 45.4
+determination	determine	29.5-1 84
+devaluation	devalue	45.4
+devastation	devastate	44 31.1
+development	develop	26.1 26.2
+development	develop	48.3 48.1.1
+deviation	deviate	23.4
+devolution	devolve	13.3
+devotion	devote	79
+deworming	deworm	10.8
+diagnosis	diagnose	29.2
+dictating	dictate	37.1.1-1
+dictation	dictate	37.1.1-1
+die	die	48.2
+differentiation	differentiate	23.1-1
+diffraction	diffract	45.4
+diffusion	diffuse	45.4
+dig	dig	35.1
+digging	dig	35.1
+diminution	diminish	45.6-1 45.4
+dining	dine	39.5
+directing	direct	26.7-1
+direction	direct	26.7-1
+disagreement	disagree	36.1 36.4-1
+disappointment	disappoint	31.1
+disarmament	disarm	10.6 31.1
+disarming	disarm	10.6 31.1
+disclosure	disclose	37.7 78-1-1
+discontinuation	discontinue	55.2
+discovery	discover	30.2 29.5-2 84
+disgust	disgust	31.1
+dishonor	dishonor	31.1
+dishonour	dishonor	31.1
+disintegration	disintegrate	45.4
+dislocation	dislocate	45.4
+disorganization	disorganize	45.4
+display	display	48.1.2
+dispute	dispute	36.4-1
+dissatisfaction	dissatisfy	31.1
+dissemination	disseminate	13.2-1
+dissent	dissent	36.1
+dissention	dissent	36.1
+dissipation	dissipate	45.4
+dissociation	dissociate	23.1-2
+dissolution	dissolve	45.4
+distension	distend	45.2
+distention	distend	45.2
+distortion	distort	26.5
+distraction	distract	31.1
+distribution	distribute	13.2-1
+disturbance	disturb	31.1
+divergence	diverge	23.4
+diversification	diversify	45.4
+diversion	divert	31.1
+dividing	divide	23.1-1 45.4
+dividing	divide	108-1
+diving	dive	35.2
+division	divide	23.1-1 45.4
+divorce	divorce	36.2
+dock	dock	9.10-1
+docking	dock	9.10-1
+dockings	dock	9.10-1
+documentation	document	25.4
+dogsledding	dogsled	51.4.1
+dominance	dominate	47.8-2
+domination	dominate	47.8-2
+dominion	dominate	47.8-2
+donation	donate	13.2-1-1
+doubling	double	45.4
+doubt	doubt	33 29.5-1
+douching	douche	41.2.1 41.1.1
+drafting	draft	26.4
+drag	drag	11.4 35.2
+draining	drain	10.6-1 10.3-1 45.4
+draw	draw	11.4 23.2 10.1
+draw_down	draw	11.4 23.2 10.1
+drawing	draw	11.4 23.2 10.1
+drawing	draw	26.7-2-1 25.2
+dream	dream	62
+dreaming	dream	62
+dredging	dredge	35.2
+dressing	dress	41.1.1
+dribbling	dribble	40.1.2
+drilling	drill	21.2-2
+drink	drink	39.1-2
+drinking	drink	39.1-2
+drive	drive	11.5
+drive_around	drive	11.5
+driving	drive	11.5
+drooling	drool	40.1.2 43.4
+drooping	droop	47.6
+drop	drop	9.4 45.6-1 51.3.1 47.7
+drop	drop	10.10
+dropping	drop	9.4 45.6-1 51.3.1 47.7
+dropping	drop	10.10
+dueling	duel	36.4-1
+dumping	dump	9.3-1-1
+duplication	duplicate	25.4
+dusting	dust	9.7-2
+dying	die	48.2
+eating	eat	39.1-1
+echo	echo	47.4
+edification	edify	45.7
+educating	educate	37.9
+education	educate	37.9
+effect	affect	31.1
+effort	effort	try-61
+ejection	eject	10.1
+elaboration	elaborate	37.11-1-1
+election	elect	29.1
+electrocoagulation	coagulate	45.4
+electrodesiccation	desiccate	45.4
+elevation	elevate	9.4
+elimination	eliminate	10.1
+emancipation	emancipate	10.5
+embrace	embrace	36.2
+employment	employ	13.5.3
+employment	employ	105.1
+emptying	empty	45.4 10.3-1
+encouragement	encourage	37.9 58.1-1-1
+encouragement	encourage	102 31.1 77.1
+end	end	55.4-1
+ending	end	55.4-1
+endowment	endow	9.8
+engagement	engage	31.1 22.2-3-2 107 13.5.3
+enrollment	enroll	107
+enrolment	enroll	107
+entering	enter	51.1-2
+entrance	enter	51.1-2
+entry	enter	51.1-2
+eradication	eradicate	10.1
+erection	erect	26.1
+erosion	erode	45.5
+eruption	erupt	48.1.1
+escape	escape	51.1-1
+establishment	establish	55.5-1 97.1 78-1-1
+estimate	estimate	54.4
+estimation	estimate	54.4
+evacuation	evacuate	10.2
+evaluation	evaluate	34.1
+evaporation	evaporate	45.4
+evasion	evade	52
+evening_out	even_out	45.4
+evolution	evolve	48.1.1, 26.2.1
+exaction	exact	13.5.2
+exam	examination	35.4
+examination	examination	35.4
+examination	examine	30.2 35.4
+excavation	excavate	35.2
+exchange	exchange	13.6-1
+excision	excise	10.1
+excitement	excite	31.1
+exclusion	exclude	65
+exclusive	exclude	65
+excommunication	excommunicate	10.1
+excoriation	excoriate	33
+execution	execute	42.1
+exenteration	exenterate	42.2 10.8
+exercise	exercise	26.8
+exercise	exercise	41.1.1
+exertion	exert	105
+exhaustion	exhaust	31.1
+exhibition	exhibit	48.1.2
+exile	exile	36.4
+existing	exist	47.1-1 39.6
+exit	exit	51.1-1
+expansion	expand	45.4
+expectation	expect	29.5-1 62
+experience	experience	30.2
+expiration	expire	40.1.3
+expiration	expire	48.2
+explanation	explain	37.1.1 78-1
+exploitation	exploit	105
+exploiting	exploit	105
+explosion	explode	43.2 45.4
+explosion	explode	45.6-1
+exposure	expose	78 48.1.2
+expression	express	48.1.2
+expulsion	expel	10.2 10.1
+extension	extend	13.3 13.2-2
+extension	extend	47.1-1
+extermination	exterminate	44
+extortion	extort	10.5
+extracting	extract	10.1
+extraction	extract	10.1
+extradition	extradite	10.2
+extrapolating	extrapolate	108-2
+extrapolation	extrapolate	108-2
+extrusion	extrude	10.1
+fabrication	fabricate	26.4
+failing	fail	neglect-75.1-1 succeed-74-3-1-1
+failure	fail	neglect-75.1-1 succeed-74-3-1-1
+fainting	faint	40.8.4
+fall	fall	45.6-1 51.1
+falling	fall	45.6-1 51.1
+fancy	fancy	31.2 32.1
+farting	fart	40.1.1
+fascination	fascinate	31.1
+fault	fault	33
+favor	favor	31.2
+favour	favor	31.2
+fax	fax	37.4
+fear	fear	31.3, 31.2-1
+federation	federate	45.4
+feeding	feed	39.6 39.7
+feeling	feel	30.1-1-1, 30.3
+fermentation	ferment	45.5
+feud	feud	36.4-1
+feuding	feud	36.4-1
+fibrillation	fibrillate	45.4
+fight	fight	36.3-2 36.4-1
+fighting	fight	36.3-2 36.4-1
+file	file	9.10
+filing	file	9.10
+filling	fill	9.8 47.8 45.4
+filming	film	25.4
+filtration	filter	10.4.2
+find	find	84 13.5.1
+finding	find	84 13.5.1
+fine	fine	54.5
+fire	fire	17.1-1
+firing	fire	10.10
+fishing	fish	35.1 13.7
+fissuring	fissure.	45.1
+fit	fit	26.9 9.3-1 54.3
+fitting	fit	26.9 9.3-1 54.3
+fix	fix	22.3-2 54.4
+fixation	fixate	87.1 22.3-2-1
+flaking	flake	21.2-1
+flash	flash	40.3.2 43.1
+flashing	flash	40.3.2 43.1
+flattening	flatten	21.2-1 45.4
+fleeing	flee	51.1-1
+flexion	flex	40.3.2
+flickering	flicker	43.1
+flight	flee	51.1-1
+flight	fly	51.3.2-2-1 11.5-1 51.4.2
+flipping	flip	17.1-1
+floating	float	47.3 51.3.2-2 11.2-1 51.3.1
+flood	flood	9.8 45.4
+flooding	flood	9.8 45.4
+flossing	floss	41.2.1
+flotation	float	47.3 51.3.2-2 11.2-1 51.3.1
+flow	flow	47.2
+fluctuation	fluctuate	45.6-1
+flushing	flush	10.4.1
+flushing	flush	40.1.1
+fluttering	flutter	47.3 40.3.2
+flying	fly	51.3.2-2-1 11.5-1 51.4.2
+foaming	foam	43.4 47.2
+following	follow	87.2-1 51.6
+forgiving	forgive	33
+formation	form	48.1.1 26.4 48.1.2
+formatting	format	55.5-1
+forming	form	48.1.1 26.4 48.1.2
+formulation	formulate	26.1 26.4
+forwarding	forward	11.1-1
+foundation	found	55.5-1 97.1
+founding	found	55.5-1 97.1
+freeing	free	80-1
+freeze	freeze	57 45.4
+freezing	freeze	57 45.4
+fright	frighten	31.1
+frost	frost	45.4
+frustration	frustrate	31.1
+function	function	29.6
+functioning	function	29.6
+fusion	fuse	22.1-1-1 22.3-1-1
+gain	gain	13.5.1-1
+gain	gain	45.6-1
+gamble	gamble	70 94
+gambling	gamble	70 94
+gathering	gather	22.3-2 47.5.2 13.5.1
+gauge	gauge	34.2 54.4
+generating	generate	27 26.2
+generation	generate	27 26.2
+germination	germinate	45.5
+gesture	gesture	40.3.1
+giving	give	13.1-1
+glare	glare	30.3 40.2
+glimpse	glimpse	30.2
+going	go	51.1
+gossiping	gossip	37.6
+gouging	gouge	21.2-1
+grabbing	grab	15.1, 13.5.2, 10.5-1
+grading	grade	29.10
+grading	grade	45.4
+grafting	graft	22.3-2-1
+grant	grant	13.3 29.5-2
+granting	grant	13.3 29.5-2
+granulation	granulate	45.4
+grasp	grasp	20-1 15.1-1 87.2-1
+greeting	greet	33
+grievance	complain	37.8
+grinding	grind	26.1 40.3.2 21.2-1
+grip	grip	20-1 15.1-1
+groan	groan	37.3 40.2
+groaning	groan	37.3 40.2
+grooming	groom	41.1.2
+grooving	groove	9.9
+grouping	group	22.3-2 47.5.2 29.10
+growing	grow	26.1 26.2.1
+growing	grow	45.6-1-1 45.4
+growing	grow	48.1.1
+growing_up	grow_up	26.2
+grumble	grumble	37.3 37.8
+guarantee	guarantee	13.3 99 37.13 29.5-2
+guarding	guard	29.8-1
+guess	guess	29.5-1
+guidance	guide	59-1 51.7
+gushing	gush	31.3-8
+gushing	gush	48.1.1 43.4
+gutting	gut	10.7
+hacking	hack	23.2
+hacking	hack	26.1 21.1-1
+hacking_away	hack_away	26.1 23.2 21.1-1
+hallucination	hallucinate	31.3-8
+halt	halt	55.4 45.4
+hammering	hammer	18.1-1 18.4-1
+hand-delivery	handdeliver	11.1
+handdelivery	handdeliver	11.1
+handle	handle	15.1 98
+handling	handle	15.1 98
+handwritting	handwrite	26.7-2-1 25.2 37.1.1-1-1 37.7 37.11-1
+hanging	hang	40.3.2 47.6 9.2-1 42.2 9.7-1
+hanging	hang	47.6 50
+hankering	hanker	32.2-1
+happening	happen	48.3
+happiness	happy	31.1
+harassment	harass	31.1
+hardening	harden	45.4
+harm	harm	31.1
+harming	harm	31.1
+hating	hate	31.2-1
+hatred	hate	31.2-1
+hauling	haul	11.4
+healing	heal	45.4
+hearing	hear	30.1-1-1 84-1-1
+heating	heat	45.3 45.4
+heightening	heighten	45.4
+help	help	72-1
+hemorrhaging	hemorrhage	40.1.3
+herding	herd	47.5.2
+hesitation	hesitate	53.1
+hiding	hide	16-1
+highjacking	hijack	59-1
+highlighting	highlight	41.2.2
+hijacking	hijack	59-1
+hiking	hike	51.3.2
+hint	hint	37.7-2
+hire	hire	13.5.1 13.5.3
+hiring	hire	13.5.1 13.5.3
+hissing	hiss	37.3
+hit	hit	18.1-1 17.1-1 47.8-1 18.4 40.8.3
+hit	hit	42.1
+hitting	hit	18.1-1 17.1-1 47.8-1 18.4 40.8.3
+hold	hold	15.1 49.2 15.2 100.1 15.3
+holding	hold	15.1 49.2 15.2 100.1 15.3
+holding	hold	29.5-1
+holding	hold	54.3
+holding	hold	55.6
+holding_on	hold_on	15.1-1
+holiday	holiday	56
+holidaying	holiday	56
+hopping	hop	47.5.1-1 51.3.2-1
+hosting	host	29.8-1
+housing	house	54.3 9.10
+humidification	humidify	45.4
+humiliation	humiliate	31.1
+hunting	hunt	35.1
+hurry	hurry	51.3.2-2 53.2
+hurting	hurt	31.1, 31.3, 40.8.1
+hurting	hurt	40.8.3-2 31.1
+hybridization	hybridize	45.4
+hydration	hydrate	45.4
+hyperextension	hyperextend	45.2
+hyperventilating	hyperventilate	47.5.3
+hyperventilation	hyperventilate	47.5.3
+hypoventilation	hypoventilate	40.1.2
+identification	identify	29.2-1-1
+identification	identify	88.2
+illumination	illuminate	25.3
+illustration	illustrate	25.3
+imagination	imagine	29.2-1-1 29.9-1-1-1
+imitation	imitate	101
+immersion	immerse	9.1
+impediment	impede	67
+implantation	implant	9.1
+implementation	implement	55.5-1
+imposition	impose	63
+improvement	improve	45.4
+incision	incise	25.1
+incitement	incite	59
+inclusion	include	107 65
+incorporation	incorporate	22.2-1
+increase	increase	45.6-1 45.4
+incrimination	incriminate	33
+incubation	incubate	45.4
+indication	indicate	78-1
+indictment	indict	33
+induction	induce	27
+induration	indurate	45.4
+infection	infect	9.8
+inference	infer	97.2 29.5-1
+infestation	infest	9.8
+inflammation	inflame	31.1
+inflation	inflate	45.4
+influence	influence	59-1
+ingestion	ingest	39.4-1
+inhalation	inhale	40.1.3-2
+inheritance	inherit	13.5.2
+inhibition	inhibit	67
+initiation	initiate	55.5-1
+injection	inject	9.8
+injury	injure	40.8.3-2
+innovation	innovate	55.5
+input	input	9.1
+input	input	37.11
+inquiry	inquire	37.1.2
+inscription	inscribe	25.1
+insertion	insert	9.1-1
+insistence	insist	37.7
+inspection	inspect	30.2 35.4
+inspiration	inspire	27.1-1, 31.1
+installation	install	9.1-1 29.1
+installment	install	9.1-1 29.1
+institution	institute	55.5-1
+instruction	instruct	37.9
+insulation	insulate	9.9
+insult	insult	33.1-1, 31.1
+integration	integrate	22.2
+intensification	intensify	45.4
+intent	intend	61.1 61.2-1-1 62
+intention	intend	61.1 61.2-1-1 62
+interaction	interact	36.1
+interception	intercept	98
+interest	interest	31.1
+interesting	interest	31.1
+interpolation	interpolate	108-2
+interpretation	interpret	29.2
+interpreting	interpret	29.2
+interrogation	interrogate	37.1.3
+intersection	intersect	47.8-1
+interspersing	intersperse	9.8 22.2-2-1
+interview	interview	37.1.3
+intimidation	intimidate	31.1
+intonation	intone	26.7-1
+intoxication	intoxicate	31.1
+introduction	introduce	22.2-3-1 55.5-1
+intrusion	intrude	48.1.2
+inundation	inundate	9.8
+invagination	invaginate	45.4
+invention	invent	26.4 26.3-1
+inversion	invert	45.4
+investigation	investigate	30.2 35.4
+investment	invest	13.4.2
+invitation	invite	102 60
+involvement	involve	103 107 86.2-1
+irritation	irritate	31.1
+isolation	isolate	16 29.10
+issuance	issue	13.3 13.4.1 48.1.1
+issue	issue	13.3 13.4.1 48.1.1
+itching	itch	40.8.1
+jab	jab	18.1-1
+jeering	jeer	40.2
+jogging	jog	51.3.2-2-1
+joining	join	22.1-2-1
+joining_up	join_up	22.1-2-1
+joke	joke	37.6
+jolt	jolt	31.1
+journey	journey	51.3.2-1
+judgement	judge	34.2 29.4-1-1-2 29.2
+judgment	judge	34.2 29.4-1-1-2 29.2
+jump	jump	45.6-1
+jump	jump	51.3.2
+jumping	jump	51.3.2
+justification	justify	37.1.1
+kayaking	kayak	51.4.1-1
+keeping	keep	55.6
+keeping	keep	55.6 15.2
+keeping_up	keep_up	55.6
+keratinization	keratinize	45.4
+kick	kick	23.2 40.3.2 49 11.4-1-1 18.1-1 17.1-1-1 18.2
+kicking	kick	23.2 40.3.2 49 11.4-1-1 18.1-1 17.1-1-1 18.2
+kidnapping	kidnap	10.5
+kill	kill	42.1-1 42.3
+killing	kill	42.1-1 42.3
+killing	kill	74
+kiss	kiss	36.2 20-1
+kissing	kiss	36.2 20-1
+kneading	knead	26.5
+knifing	knife	42.2 18.3
+knitting	knit	26.1
+knock	knock	18.1-1 17.1-1 18.4-1
+knowledge	know	comprehend-87.2-1 conjecture-29.5-1 consider-29.9-1-1
+labeling	label	9.9 29.3 25.3
+landing	land	9.10-1
+laugh	laugh	40.2
+laughing	laugh	40.2
+launch	launch	17.1-1-1 55.5-1
+laying	lay	9.2
+lead	lead	51.7
+lead	lead	59.1, 27.2
+lead	lead	95.2.2
+leadership	lead	95.2.2
+leading	lead	51.7
+leading	lead	59.1, 27.2
+leading	lead	95.2.2
+leak	leak	43.4
+leakage	leak	43.4
+leaking	leak	43.4
+leap	leap	51.3.2-1
+leaping	leap	51.3.2-1
+learning	learn	14-1 84-1-1
+leasing	lease	13.1-1
+leasing	lease	13.5.1
+lending	lend	13.1
+lesson	lesson	37.1
+levitation	levitate	45.4
+liberation	liberate	10.5 80
+license	license	101
+licensing	license	101
+lifting	lift	9.4
+ligation	ligate	22.3-2-1
+liking	like	32.1-1-1 31.2-1
+limit	limit	76
+limitation	limit	76
+lining	line	9.8 47.8
+linkage	link	22.4 22.1-2-1
+liquidation	liquidate	42.1
+listening	listen	30.3 35.5
+living	live	47.1-1 46 39.6
+loading	load	9.7-2
+loan	loan	13.1
+lobbying	lobby	58.1
+locking	lock	22.4
+lodging	lodge	9.10-1 9.1
+lodging	lodge	46
+logging	log	13.7
+look	look	30.3 35.5
+look	look	30.4
+looking	look	30.3 35.5
+loosening	loosen	45.4
+loss	lose	13.2
+love	love	31.2-1
+lowering	lower	9.4
+lubrication	lubricate	9.9
+lurking	lurk	47.1-1
+maceration	macerate	45.4
+magnifying	magnify	45.4
+maintenance	maintain	55.6 29.5-2
+make	make	26.1-1
+make_up	make_up	26.1-1
+making	make	26.1-1
+manifestation	manifest	48.1.2
+manipulation	manipulate	59-1
+manufacturing	manufacture	26.4
+march	march	51.3.2-2-1
+marginalisation	marginalize	45.7
+marginalization	marginalize	45.7
+mark	mark	25.1
+marking	mark	25.1
+marriage	marry	36.2 22.2-3-1-1
+massacre	massacre	42.1
+massage	massage	20-1
+match	match	22.2-1
+matching	match	22.2-1
+maturation	maturate	26.2 45.4
+maturity	maturate	26.2 45.4
+measure	measure	54.1-1
+measurement	measure	54.1-1
+measuring	measure	54.1-1
+meditation	meditate	31.3-8
+meeting	meet	36.3-1
+memorization	memorize	14-2
+mentation	mentate	29.9 62
+mention	mention	37.7-1
+meowing	meow	38
+merger	merge	22.1-1-1
+merging	merge	22.1-1-1
+militarization	militarize	45.7
+milling	mill	21.2-2
+mining	mine	35.1 10.9
+misappropriation	misappropriate	10.5
+misdirection	misdirect	51.7
+misinterpretation	misinterpret	87.2
+misperception	misperceive	30.2 29.2
+missing	miss	31.2
+mistrust	mistrust	31.2
+misunderstanding	misunderstand	87.2
+mixing	mix	22.1-1-1 26.3-1
+moaning	moan	37.3 40.2
+mobilization	mobilize	45.4
+mobilizing	mobilize	45.4
+model	model	26.4
+modeling	model	26.4
+modeling	model	29.8
+moderation	moderate	45.4
+modernization	modernize	45.4
+modulation	modulate	45.4
+moisturization	moisturize	41.1.1
+monitoring	monitor	35.4
+mopping	mop	10.4.2-1
+moralizing	moralize	37.11-1
+motivation	motivate	59
+mourning	mourn	31.3, 31.2
+move	move	45.6 11.2 51.3.1
+movement	move	45.6 11.2 51.3.1
+moving	move	31.1
+moving	move	45.6 11.2 51.3.1
+mowing	mow	21.2-2
+muffling	muffle	42.3
+murder	murder	42.1
+murdering	murder	42.1
+mutation	mutate	26.6.1
+mutilation	mutilate	44
+muttering	mutter	37.3
+myelosuppression	myelosuppress	16 42.3
+naming	name	29.3
+nap	nap	40.4
+narration	narrate	37.1.1
+narrowing	narrow	45.4
+nationalization	nationalize	45.4
+navigation	navigate	51.4.2
+need	need	32.1-1-1 103
+neglect	neglect	75-1-1
+negotiating	negotiate	36.1
+negotiation	negotiate	36.1
+neighboring	neighbor	47.8
+networking	network	22.1
+nomination	nominate	29.1
+nonexisting	nonexistent	47.1-1
+normalization	normalize	45.4
+note	note	30.2
+notice	notice	25.2 37.11 37.7 37.1.1 26.7
+notice	notice	30.1-1
+noticing	notice	30.1-1
+notification	notify	37.2 37.9
+notifying	notify	37.2 37.9
+nudging	nudge	17.1-1
+nursing	nurse	29.8-1
+oath	oath	13.3 37.13
+objection	object	37.8
+obligation	obligate	59
+obliteration	obliterate	44
+observation	observe	30.2 35.4
+observation	observe	37.7-1 29.5-2
+obsession	obsess	31.1, 31.3
+obstructing	obstruct	67
+obstruction	obstruct	67
+occlusion	occlude	45.4
+occupation	occupy	31.1
+offense	offend	31.1
+offer	offer	13.3
+offering	offer	13.3
+omission	omit	10.1 75-1
+oozing	ooze	43.4
+opacification	opacify	45.4
+opening	open	47.6 40.3.2 45.4
+opening_up	open_up	45.4
+operating	operate	45.4
+operation	operate	45.4
+opposition	oppose	22.2-3
+order	order	9.1
+order	order	13.5.1
+order	order	60-1
+ordering	order	13.5.1
+ordering	order	60-1
+ordinance	ordain	29.1
+organization	organize	59-1 55.5-1 26.4
+organizing	organize	59-1 55.5-1 26.4
+ossification	ossify	45.4
+ousting	oust	10.1
+outfitting	outfit	41.3.3 13.4.2-1
+outrage	outrage	31.1
+overestimation	overestimate	54.4
+overlap	overlap	22.2-1
+overlapping	overlap	22.2-1
+overpayment	overpay	68
+ownership	own	100
+packaging	package	22.3-2-1
+packing	pack	9.7-1-1
+painting	paint	25.2 9.9
+painting	paint	26.7-2-1 24
+painting	paint	29.2
+pairing	pair	22.2-2 22.3-2 22.1-2-1
+palliation	palliate	80
+palpitation	palpitate	40.8.2
+pant	pant	40.1.1
+parade	parade	51.3.2
+paralysis	paralyze	45.4
+parching	parch	45.3
+pardon	pardon	33
+participation	participate	73-2
+partition	partition	23.3
+pass	pass	13.1 11.1-1 17.1-1
+passage	pass	48.3 47.7
+passing_on	pass_on	11.1
+patent	patent	101
+patrol	patrol	35.2
+pawn	pawn	13.1-1
+payment	pay	68-1
+perception	perceive	30.2
+percolation	percolate	43.4 45.3
+perfection	perfect	45.4
+perforation	perforate	21.2-1
+performance	perform	26.7-1
+permission	permit	64.3-1, 64.1-1
+persecution	persecute	33
+persistence	persist	47.1-1
+persuasion	persuade	59
+perturbation	perturb	31.1
+phoning	phone	13.5.1, 37.4.2-1, 37.4.1
+photo	photograph	25.4
+picketing	picket	35.4
+picking	pick	13.5.1
+piercing	pierce	19
+pioneering	pioneer	29.8-1
+pitch	pitch	17.1-1
+pitching	pitch	17.1-1
+pity	pity	31.2
+placement	place	9.1-2
+plan	plan	62
+planning	plan	62
+planting	plant	9.1-1 55.5-1 9.7-2
+plaquing	plaque	47.5.2 13.5.2
+play	play	26.7-1-1
+playing	play	26.7-1-1
+plot	plot	25.2 36.1
+plugging	plug_up	9.8
+plunge	plunge	45.6-1 47.7
+plunge	plunge	51.1
+poisoning	poison	42.2
+poking	poke	19 35.5
+polarization	polarize	45.4
+policing	police	29.8-1
+polish	polish	9.9 10.4.1
+pollution	pollute	9.8-1
+pooling	pool	22.1-2-1
+popping	pop	43.2
+popping	pop	45.4
+portrayal	portray	29.2-1-1
+posing	pose	29.6-2
+posing	pose	37.1.1
+positioning	position	9.1
+post	post	11.1
+posting	post	11.1
+pounding	pound	18.1-1
+pounding	pound	26.1
+pouring	pour	9.5 43.4
+praise	praise	29.2, 33.1-1-1
+preaching	preach	37.11-1 37.1.1
+precedence	precede	47.8
+preconception	preconceive	29.2-1 97.2
+prediction	predict	78
+preference	prefer	32.1-1-1 31.2
+pregnancy	impregnate	9.8
+preoccupation	preoccupy	31.1
+preparation	prepare	26.3-1
+preparation	prepare	55.5-1
+presentation	present	13.4.1 48.1.2
+presenting	present	13.4.1 48.1.2
+preservation	preserve	85
+pressing	press	59 12-1-1
+presumption	presume	29.5-1
+prevention	prevent	67
+price	price	54.4
+pricing	price	54.4
+printing	print	25.2
+proceeding	proceed	55.1
+procession	proceed	55.1
+procurement	procure	13.5.1
+producing	produce	26.7-2 26.4
+production	produce	26.7-2 26.4
+profession	profess	29.4-1-1-3
+progress	progress	45.5
+progression	progress	45.5
+prohibition	prohibit	67
+projection	project	34.2
+projection	project	47.6
+proliferation	proliferate	45.4
+promise	promise	13.3
+promotion	promote	102
+prompting	prompt	59
+pronunciation	pronounce	29.3
+proof	prove	97.2 29.4-1-1 78-1-1
+prophesy	prophesy	29.5-1
+proposal	propose	37.7-1 62 48.1.2
+proposition	propose	37.7-1 62 48.1.2
+prosecution	prosecute	33
+prospering	prosper	47.1-1 39.6
+prostitution	prostitute	29.8
+protection	protect	85
+protest	protest	71
+protesting	protest	71
+protrusion	protrude	47.6
+provision	provide	13.4.1-2
+provocation	provoke	31.1, 27.1-1
+publication	publish	26.4-1
+publishing	publish	26.4-1
+puckering	pucker	40.3.2 40.8.2
+pull	pull	11.4 12-1 23.2 40.8.3-1-1 15.1-1 13.5.1
+pulling	pull	11.4 12-1 23.2 40.8.3-1-1 15.1-1 13.5.1
+pulling_out	pull_out	82-1
+pulsation	pulsate	47.3
+pulse	pulse	47.3
+pumping	pump	9.7-1
+punch	punch	21.2-2 18.2
+punching	punch	21.2-2 18.2
+punctuation	punctuate	9.9
+punishment	punish	33
+purchase	purchase	13.5.2-1
+pursuit	pursue	51.6
+push	push	23.2 9.3-1-1 11.4-1-1 15.1-1 12-1-1
+quadrupling	quadruple	45.4
+qualification	qualify	29.6
+quarreling	quarrel	36.4
+question	question	37.1.3
+questioning	question	37.1.3
+quotation	quote	37.1.1
+quote	quote	37.1.1
+racing	race	51.3.2-2
+radiation	radiate	43.4
+rage	rage	47.2
+raid	raid	35.4
+raise	raise	40.3.2 9.4
+raising	raise	40.3.2 9.4
+rambling	ramble	51.3.2-1
+ranking	rank	29.6 29.2
+ranting	rant	37.3 37.11-1
+rating	rate	29.6 29.1 54.4
+ration	ration	13.3
+rationing	ration	13.3
+re-creation	recreate	26.4
+re-education	reeducate	37.1.1
+re-election	reelect	29.1
+reaction	react	31.3-9
+readiness	ready	26.3-1
+reading	read	14-1 54.1-1 84-1-1 37.1.1-1
+reaffirmation	reaffirm	31.2 29.5-2 78-1-1
+realization	realize	29.5-1 84
+reapproximation	approximate	34.2 54.4
+reasoning	reason	97.2
+rebellion	rebel	71
+rebuilding	rebuild	26.4
+recall	recall	10.2
+receding	recede	51.1
+reception	receive	13.5.2
+recertification	recertify	29.2
+recession	recede	51.1
+recirculation	recirculate	47.3
+recital	recite	26.7-1-1 37.1.1
+reckoning	reckon	70 29.9-1
+recognition	recognize	29.9 30.2 29.5
+recognition	recognize	33
+recollection	recollect	29.2-1-1
+recommendation	recommend	37.7-1-1-1
+reconstitution	reconstitute	26.4-1
+recording	record	25.4
+recovery	recover	13.5.2
+recreation	recreate	26.4
+recruiting	recruit	29.7 13.5.3
+recruitment	recruit	29.7 13.5.3
+redemption	redeem	10.5
+reduction	reduce	42.3 76
+reeducation	reeducate	37.1.1
+reelection	reelect	29.1
+referral	refer	13.2
+referring	refer	13.2
+reflection	reflect	31.3-8
+refund	refund	13.1
+regard	regard	30.2 29.2
+register	register	54.1-1
+registration	register	101
+regret	regret	31.2-1
+rehydration	hydrate	45.4
+reinjection	inject	9.8
+reiteration	reiterate	37.7-1
+rejection	reject	77
+rejuvenation	rejuvenate	31.1
+relaxation	relax	31.1
+relay	relay	37.4 37.1.1
+release	release	80-1
+releasing	release	80-1
+reliance	rely	70
+relief	relieve	10.6
+remaining	remain	47.1-1
+remark	remark	37.7-1 37.11-1
+remarriage	remarry	22.2-3-1-1
+remembering	remember	29.2-1-1 29.9-1-1-1
+remembrance	remember	29.2-1-1 29.9-1-1-1
+removal	remove	10.2 10.1 10.10
+remuneration	remunerate	33
+rendering	render	13.1
+rendition	render	13.1
+renegotiation	renegotiate	36.1
+renomination	nominate	29.1
+rental	rent	13.1-1
+rental	rent	13.5.1
+renting	rent	13.1-1
+renting	rent	13.5.1
+reopening	reopen	45.4
+reorganization	reorganize	26.4-1
+repayment	pay	68-1
+repeat	repeat	37.7-1 26.8 55.4
+repetition	repeat	37.7-1 26.8 55.4
+replacement	replace	13.6
+replay	replay	26.7-2-1
+reply	reply	37.7
+report	report	37.7-1 29.2-1-2 29.9-1
+reporting	report	37.7-1 29.2-1-2 29.9-1
+representation	representation	29.2-1-1
+reproduction	reproduce	45.4
+request	request	58.2
+requirement	require	103 60-1
+rescue	rescue	10.5
+reservation	reserve	13.5.1
+residence	reside	47.1-1 46
+resonance	resonate	47.4
+resort	resort	26.6.2
+respect	respect	31.2
+responding	respond	37.7
+response	respond	37.7
+rest	rest	47.6 9.2-1
+resting	rest	47.6 9.2-1
+restitution	restore	13.2
+restoration	restore	13.2
+restraint	restrain	67 76
+restriction	restrict	76
+resumption	resume	55.1-1
+retaliation	retaliate	71
+retirement	retire	10.11 82-3
+retracting	retract	10.1
+retraction	retract	10.1
+retreat	retreat	51.1 82-3
+retrieval	retrieve	13.5.2
+return	return	11.1 13.2-2
+return	return	26.6.2
+return	return	51.1
+revelation	reveal	37.10 37.7-1 29.2-1-2 78-1-1 48.1.2
+reversal	reverse	45.4
+reverse	reverse	45.4
+reversion	revert	26.6.2
+revitalization	revitalize	31.1
+revival	revive	45.4
+ride	ride	51.4.2
+riding	ride	51.4.2
+ring	ring	43.2
+ringing	ring	43.2
+ripening	ripen	45.4
+ripple	ripple	9.8 47.2
+rise	rise	45.6-1 47.6 51.1 50 48.1.1
+risk	risk	94-1
+roll	roll	26.1 9.6 47.4 23.2 22.3-2 40.3.2 51.3.2-2 43.2 11.2-1 51.3.1 45.2 26.3-1
+rolling	roll	26.1 9.6 47.4 23.2 22.3-2 40.3.2 51.3.2-2 43.2 11.2-1 51.3.1 45.2 26.3-1
+rotation	rotate	47.3 9.6 51.3.1
+round	round	47.7
+rowing	row	11.5 51.4.2
+rubbing	rub	40.3.2 20-1 10.4.1-1 9.7-1
+ruin	ruin	44
+run	run	47.5.1-1 51.3.2-2-1
+run_up	run_up	47.7
+running	run	11.4
+running	run	18.4
+running	run	47.5.1-1 51.3.2-2-1
+running	run	47.7
+rush	rush	51.3.2-2-1
+sacking	sack	10.10
+sacrifice	sacrifice	13.2-1-1
+sailing	sail	51.4.2
+sale	sell	13.1-1
+salivation	salivate	31.3-8 40.1.1
+salutation	salute	40.3.3 33
+salvage	salvage	10.5-1
+satiation	satiate	31.1
+satisfaction	satisfy	31.1
+saturation	saturate	9.8
+saving	save	13.5.1-1
+saving	save	13.5.1-1 54.5
+scaling	scale	10.7
+scalloping	scallop	45.3
+scanning	scan	30.2 35.4
+scare	scare	31.1
+scaring	scare	31.1
+scarring	scar	25.1
+scattering	scatter	9.7-1
+scheduling	schedule	26.4-1
+schmoozing	schmooze	37.6
+scolding	scold	33
+scooping	scoop	9.3
+scratching	scratch	40.8.3-2 10.4.1-1 21.1-1 18.2
+scream	scream	37.3
+scruple	scruple	53.1-1
+sculpting	sculpt	26.1-1
+search	search	35.2
+searching	search	35.2
+seasoning	season	9.8
+seclusion	seclude	16
+seduction	seduce	59-1
+seeding	seed	9.9 9.7-1
+seeking	seek	35.1
+segregation	segregate	23.3 23.1-1
+seizure	seize	15.1, 13.5.2, 10.5
+selection	select	13.5.2 29.2
+selling	sell	13.1-1
+sensation	sense	30.1-1
+sense	sense	30.1-1
+sensing	sense	30.1-1
+separation	separate	10.1 29.10 23.1-2
+sequestering	sequester	10.5 16
+service	serve	13.4.1-1
+service	serve	29.6-2 104
+servicing	serve	13.4.1-1
+serving	serve	13.4.1-1
+serving	serve	29.6-2 104
+serving_up	serve_up	13.4.1-1
+setting	set	41.2.2 25.1 9.1-2
+settlement	settle	89
+shading	shade	85
+shadowing	shadow	51.6
+shaking	shake	47.3 40.3.2 9.3-1-1 31.1 40.6 26.5
+shame	shame	31.1
+shaming	shame	31.1
+shaming	shame	59-1 33
+shape	shape	27 26.1-1 48.1.2
+shaving	shave	41.2.1 41.1.1 10.4.1
+shearing	shear	10.4.2-1
+shedding	shed	43.4
+shift	shift	26.6.2 45.6 11.1
+shifting	shift	26.6.2 45.6 11.1
+shipbuilding	shipbuilding	26.1-1
+shipping	ship	11.1-1
+shock	shock	31.1
+shoot	shoot	42.2
+shooting	shoot	42.2
+shopping	shop	35.2
+shortening	shorten	45.4
+shot	shoot	17.1-1
+show	show	37.1.1-1-1 40.3.2 29.5-2 78-1-1 48.1.2
+shower	shower	57 41.1.1 17.2 9.7-1
+showing	show	37.1.1-1-1 40.3.2 29.5-2 78-1-1 48.1.2
+showing_off	show_off	48.1.2
+shunting	shunt	11.1
+sight	see	29.2-1 30.1-1 29.9-1-1
+sign	signal	37.4
+signal	signal	37.4
+signing	sign	13.5.3
+signing	sign	25.1
+signing_up	sign_up	13.5.3
+simulation	simulate	55.5-1
+singing	sing	37.3 26.7-1-1 43.2
+sink	sink	45.4
+sinking	sink	45.4
+sitting	sit	47.6 9.2-1 50
+skateboarding	skateboard	51.4.1-1
+skiing	ski	51.4.1-1
+skimming	skim	10.4.1
+skirmish	skirmish	36.4-1
+slash	slash	21.1-1
+slaughter	slaughter	42.1 13.5.1
+slaying	slay	42.1
+sleeping	sleep	40.4
+slide	slide	51.3.2-2 51.3.1 11.2-1
+slowing	slow	45.4
+smack	smack	40.3.2
+smashing	smash	18.1-1 17.1-1 45.1 21.2-1
+smashing	smash	18.4-1
+smell	smell	35.3 30.1
+smuggling	smuggle	11.1-1 10.5-1
+snacking	snack	39.5
+sneezing	sneeze	40.1.1 40.2
+snoring	snore	40.1.1 40.2
+soaking	soak	9.8 10.4.1 45.4
+sobbing	sob	40.2
+softening	soften	45.4
+soiling	soil	9.8
+solution	solve	84
+solving	solve	84
+sound	sound	47.4 43.2
+sowing	sow	9.7-1
+span	span	47.8
+speaking	speak	37.5 37.11-1
+specification	specify	29.2
+speculating	speculate	29.5-1
+speculation	speculate	29.5-1
+speech	speak	37.5 37.11-1
+speeding	speed	51.3.2-2
+spelling	spell	25.2
+spending	spend	68
+spin	spin	9.6 40.8.2 51.3.1
+spin	spin	26.7-2-1
+spinning	spin	9.6 40.8.2 51.3.1
+spinning	spin	26.1
+spinning	spin	26.7-2-1
+spitting	spit	40.1.2
+splaying	splay	45.2
+split	split	23.2
+splitting	split	23.2
+spotting	spot	9.8
+spotting	spot	30.2
+spraying	spray	9.7-1
+spread	spread	9.7-1
+spread	spread	48.1.1
+spreading	spread	9.7-1
+spreading	spread	48.1.1
+spying	spy	30.2
+squeeze	squeeze	20-1 12-1-1 26.5
+squeezing	squeeze	20-1 12-1-1 26.5
+squinting	squint	40.3.1-1 30.3
+stab	stab	19 42.2 18.2
+stabbing	stab	19 42.2 18.2
+stabilization	stabilize	45.4
+stagflation	inflate	45.4
+staging	stage	26.4 55.5
+stagnation	stagnate	45.5
+staining	stain	24 9.9 9.8-1
+stalking	stalk	35.3
+stall	stall	53.1-1
+staring	stare	30.3
+start	start	55.1-1
+starting	start	55.1-1
+starvation	starve	40.7
+statement	state	37.7-1
+stay	stay	47.1-1 46
+steering	steer	51.7
+stem	stem	48.1.1
+step	step	51.3.2
+sterilization	sterilize	45.4
+stiffening	stiffen	45.4
+stigmatization	stigmatize	33
+stimulation	stimulate	59-1 31.1
+sting	sting	20-1 31.1 40.8.2
+stinging	sting	20-1 31.1 40.8.2
+stocking	stock	9.7-2 15.2
+stop	stop	55.4-1
+stoppage	stop	55.4-1
+storage	store	15.2
+straining	strain	40.8.3-2
+stratification	stratify	45.4
+stream	stream	48.1.1
+strengthening	strengthen	45.4
+stress	stress	31.3-2
+stressing	stress	9.9
+stretching	stretch	40.3.2 47.7 45.2
+stride	stride	51.3.2-1
+strike	strike	18.1-1 18.4-1
+stripping	strip	10.6 41.1.1 10.4.1-1
+stroke	stroke	25.2 20
+stroll	stroll	51.3.2-1
+struggle	struggle	36.4-1
+struggling	struggle	36.4-1
+study	study	14-1 30.2 34.1 84-1-1
+studying	study	14-1 30.2 34.1 84-1-1
+stuttering	stutter	37.3
+submission	submit	13.2-1-1
+submission	submit	95
+substitution	substitute	13.6-1-1
+success	succeed	74-1
+suction	suction	10.4.1-1
+suffering	suffer	31.3
+suggestion	suggest	37.7-1-1
+supersaturation	supersaturate	45.4
+supply	supply	13.4.1-1
+support	support	31.2 47.8 72
+supposition	suppose	29.9-2
+suppression	suppress	16 42.3
+surprise	surprise	31.1
+surrender	surrender	13.2-1-1
+surrounding	surround	9.8
+surveilance	surveil	30.2 35.4
+survey	survey	30.2 35.4
+survival	survive	47.1-1-1 39.6
+suspension	suspend	9.2-1
+suspension	suspension	10.10
+suspicion	suspect	29.5-1 81 29.9-2
+suturing	suture	22.4
+swallowing	swallow	39.3-2 40.1.1
+swat	swat	18.2
+sweating	sweat	40.1.2 43.4
+sweep	sweep	9.3-1-1 10.4.1-1
+sweep	sweep	35.2
+sweep	sweep	47.7 51.3.2-1
+sweeping	sweep	9.3-1-1 10.4.1-1
+swelling	swell	45.5 45.6-1
+swim	swim	47.5.1 51.3.2
+swimming	swim	47.5.1 51.3.2
+swing	swing	47.6 51.3.1 9.6-1
+swipe	swipe	10.5
+switch	switch	26.6.2-1 13.6-1
+switching	switch	26.6.2-1 13.6-1
+tackle	tackle	98
+tag	tag	9.9 25.3
+takeover	take_over	93
+taking	take	10.5 11.3
+taking	take	26.6.2
+taking	take	29.2
+taking	take	103 54.2 54.3
+taking_on	take_on	93
+taking_on	take_on	98
+taking_over	take_over	93
+talk	talk	37.5 37.11-1
+talking	talk	37.5 37.11-1
+tanning	tan	45.4
+tapering_off	taper_off	45.4
+tapping	tap	18.1-1 17.1-1
+tariff	tax	54.5
+taste	taste	30.4
+taste	taste	35.3 30.1
+tasting	taste	35.3 30.1
+tattooing	tattoo	25.1
+taxation	tax	54.5
+teaching	teach	37.1.1-1-1
+tearing	tear	23.2 40.8.3-1-1 45.1
+tearing	tear	51.3.2
+teasing	tease	59-1 31.1
+teething	teethe	39.2-1
+telling	tell	37.1.1-1-1 37.2-1
+temptation	tempt	59 31.1
+tension	tense	45.4
+termination	terminate	10.10
+termination	terminate	55.4
+terror	terrorism	31.1
+terrorising	terrorize	31.1
+terrorizing	terrorize	31.1
+test	test	35.4
+testimony	testify	37.11-1
+testing	test	35.4
+thanks	thank	33
+thawing	thaw	45.4
+theft	thieve	10.5
+thickening	thicken	45.4
+thieving	thieve	10.5
+thinking	think	29.9-2 62
+thinning	thin	45.4
+thought	think	29.9-2 62
+threat	threaten	31.1
+thrill	thrill	31.1
+throw	throw	17.1-1-1
+throwing	throw	17.1-1-1
+thrust	thrust	11.4-1-1 12-1-1
+thumping	thump	18.4-1 18.3 18.1
+thumping	thump	43.2
+tickling	tickle	20-1 31.1 40.8.2
+tightening	tighten	45.4
+tiling	tile	9.8 9.9
+timing	time	54.1
+tingling	tingle	40.8.2
+tip	tip	17.1-1-1
+tip	tip	54.5
+tiptoeing	tiptoe	51.3.2
+tolerance	tolerate	31.2 64
+torture	torture	31.1
+toss	toss	40.3.2 17.1-1-1 26.3-1
+tossing	toss	40.3.2 17.1-1-1 26.3-1
+touch	touch	20-1 31.1 86.2-1 47.8-1
+touching	touch	20-1 31.1 86.2-1 47.8-1
+touching_on	touch_on	86.2-1
+tow	tow	11.4
+towing	tow	11.4
+tracing	trace	25.2
+track	track	35.3 51.6
+tracking	track	35.3 51.6
+trade	trade	13.6-1
+trading	trade	13.6-1
+training	train	13.5.3
+transcription	transcribe	25.4
+transfer	transfer	11.1 13.2-2
+transformation	transform	26.6.1
+translation	translate	26.6.1
+transmission	transmit	11.1-1
+transmutation	transmute	26.6.1
+transport	transport	11.1
+transportation	transport	11.1
+trapping	trap	9.10
+travel	travel	51.3.2-1
+traveling	travel	51.3.2-1
+travelling	travel	51.3.2-1
+treating	treat	13.4.2-1
+treating	treat	29.2
+treatment	treat	29.2
+tremor	tremor	47.3 40.6
+trick	trick	59
+tunneling	tunnel	35.5-1
+turn	turn	26.6.2 26.6.1-1
+turn	turn	40.3.2 47.7 40.8.3-1-1 51.3.1
+turnabout	turnabout	26.6.2 26.6.1
+turnabout	turnabout	40.3.2 47.7 40.8.3 51.3.1
+turning	turn	40.3.2 47.7 40.8.3-1-1 51.3.1
+tutoring	tutor	29.8-1
+twist	twist	26.5 9.6-1
+twitching	twitch	40.3.2 49
+typing	type	25.2 25.4
+typing_up	type_up	25.2 25.4
+ulceration	ulcerate	45.4
+ultrafiltration	ultrafilter	45.4
+underestimation	underestimate	29.2-1
+understanding	understand	accept-77.1 comprehend-87.2-1
+undertaking	undertake	55.1 98
+undoing	undo	44
+unification	unify	22.2
+union	union	45.4
+unloading	unload	10.4.1
+update	update	37.2
+upgrade	upgrade	29.1
+urbanization	urbanize	45.4
+urging	urge	58.1
+urination	urinate	40.1.3-1 40.1.2-1
+use	use	66, 105.1, 39.1-3
+using	use	66, 105.1, 39.1-3
+utilization	utilize	105
+vacation	vacation	56
+vacuuming	vacuum	10.4.2-1
+valuation	value	54.4
+variation	vary	23.4 45.6-1 45.4
+vault	vault	51.3.2-1
+ventilation	ventilate	45.4
+verification	verify	101 37.1.1 78-1-1
+vexation	vex	31.1
+vibration	vibrate	47.3 45.4
+view	view	29.2-1 29.9-1
+view	view	30.2
+viewing	view	30.2
+visit	visit	36.3-1
+visiting	visit	36.3-1
+visualization	visualize	29.2-1-1
+vocalization	vocalize	37.7
+voice	voice	37.7
+volunteering	volunteer	37.7 29.8
+vomiting	vomit	40.1.2
+vote	vote	29.3
+voting	vote	29.3
+voyage	voyage	51.4.2
+waiting	wait	47.1-1
+walk	walk	51.3.2
+walking	walk	51.3.2
+war	war	36.4-1
+warfare	war	36.4-1
+warming	warm	45.4
+warning	warn	37.9-1
+washing	wash	41.2.1 41.1.1 10.4.1-1 26.3-2
+waste	waste	44 68 66-1
+wasting	waste	44 68 66-1
+watch	watch	35.2 30.2
+watching	watch	35.2 30.2
+watering	water	9.9
+wave	wave	47.3 40.3.1-1
+waxing	wax	41.2.2 9.9
+waxing	wax	48.1.1
+weakening	weaken	45.4
+weaning	wean	10.6
+wedding	wed	22.2-3-1-1
+weeping	weep	40.1.2 31.3-3 40.2
+welcome	welcome	33 65
+westernization	westernize	45.4
+wetting	wet	45.4
+whack	whack	18.1
+wheezing	wheeze	40.1.1 43.2
+whining	whine	37.3 38 37.8 43.2
+whitewash	whitewash	10.6
+whooping	whoop	37.3
+whooshing	whoosh	43.2
+widening	widen	45.4
+win	win	13.5.1
+winning	win	13.5.1
+wish	wish	32.2-1 62
+withdrawal	withdraw	10.1 10.11 51.1 82-3
+wonder	wonder	31.3-1
+work	work	39.6
+working	work	26.5
+worrying	worry	31.3-2
+wreck	wreck	44
+wrestling	wrestle	36.4-1
+wringing	wring	40.3.2 20-1
+write	write	26.7-2-1 25.2 37.1.1-1-1 37.7 37.11-1
+writing	write	26.7-2-1 25.2 37.1.1-1-1 37.7 37.11-1
+yapping	yap	37.3 38
+yawning	yawn	40.1.1 40.2
+yelling	yell	37.3 38
+yellowing	yellow	45.4

--- a/semparse-core/src/main/resources/mappings/pbvn-mappings.json
+++ b/semparse-core/src/main/resources/mappings/pbvn-mappings.json
@@ -1751,7 +1751,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -1759,7 +1759,7 @@
               },
               {
                 "number": "A2",
-                "vntheta": "Recipient"
+                "vntheta": "Experiencer"
               }
             ]
           }
@@ -20838,7 +20838,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -20846,7 +20846,7 @@
               },
               {
                 "number": "A2",
-                "vntheta": "Recipient"
+                "vntheta": "Experiencer"
               }
             ]
           }
@@ -22782,7 +22782,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -28843,7 +28843,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -28851,7 +28851,7 @@
               },
               {
                 "number": "A2",
-                "vntheta": "Recipient"
+                "vntheta": "Experiencer"
               }
             ]
           },
@@ -31556,7 +31556,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -31564,7 +31564,7 @@
               },
               {
                 "number": "A2",
-                "vntheta": "Recipient"
+                "vntheta": "Experiencer"
               }
             ]
           }
@@ -38215,7 +38215,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -39481,7 +39481,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -39489,7 +39489,7 @@
               },
               {
                 "number": "A2",
-                "vntheta": "Recipient"
+                "vntheta": "Experiencer"
               }
             ]
           }
@@ -39637,7 +39637,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -39645,7 +39645,7 @@
               },
               {
                 "number": "A2",
-                "vntheta": "Recipient"
+                "vntheta": "Experiencer"
               }
             ]
           }
@@ -53680,7 +53680,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -53688,7 +53688,7 @@
               },
               {
                 "number": "A2",
-                "vntheta": "Recipient"
+                "vntheta": "Experiencer"
               }
             ]
           }
@@ -54241,7 +54241,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -54249,7 +54249,7 @@
               },
               {
                 "number": "A2",
-                "vntheta": "Recipient"
+                "vntheta": "Experiencer"
               }
             ]
           }
@@ -74092,7 +74092,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -75394,7 +75394,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -75402,7 +75402,7 @@
               },
               {
                 "number": "A2",
-                "vntheta": "Recipient"
+                "vntheta": "Experiencer"
               }
             ]
           },
@@ -78118,7 +78118,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -82367,7 +82367,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -82375,7 +82375,7 @@
               },
               {
                 "number": "A2",
-                "vntheta": "Recipient"
+                "vntheta": "Experiencer"
               }
             ]
           },
@@ -85487,7 +85487,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -85495,7 +85495,7 @@
               },
               {
                 "number": "A2",
-                "vntheta": "Recipient"
+                "vntheta": "Experiencer"
               }
             ]
           }
@@ -90088,7 +90088,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -90096,7 +90096,7 @@
               },
               {
                 "number": "A2",
-                "vntheta": "Recipient"
+                "vntheta": "Experiencer"
               }
             ]
           },
@@ -111419,7 +111419,7 @@
             "roles": [
               {
                 "number": "A0",
-                "vntheta": "Causer"
+                "vntheta": "Pivot"
               },
               {
                 "number": "A1",
@@ -116751,6 +116751,210 @@
               {
                 "number": "A1",
                 "vntheta": "Topic"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "lemma": "schedule",
+    "mappings": [
+      {
+        "id": "schedule.01",
+        "mappings": [
+          {
+            "vncls": "26.4",
+            "roles": [
+              {
+                "number": "A0",
+                "vntheta": "Agent"
+              },
+              {
+                "number": "A1",
+                "vntheta": "Result"
+              },
+              {
+                "number": "A2",
+                "vntheta": "Beneficiary"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+    {
+    "lemma": "program",
+    "mappings": [
+      {
+        "id": "program.01",
+        "mappings": [
+          {
+            "vncls": "26.4",
+            "roles": [
+              {
+                "number": "A0",
+                "vntheta": "Agent"
+              },
+              {
+                "number": "A1",
+                "vntheta": "Result"
+              },
+              {
+                "number": "A2",
+                "vntheta": "Beneficiary"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "lemma": "finance",
+    "mappings": [
+      {
+        "id": "finance.01",
+        "mappings": [
+          {
+            "vncls": "13.4.2-1",
+            "roles": [
+              {
+                "number": "A0",
+                "vntheta": "Agent"
+              },
+              {
+                "number": "A1",
+                "vntheta": "Recipient"
+              },
+              {
+                "number": "A2",
+                "vntheta": "Theme"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "lemma": "fund",
+    "mappings": [
+      {
+        "id": "fund.01",
+        "mappings": [
+          {
+            "vncls": "13.4.2-1",
+            "roles": [
+              {
+                "number": "A0",
+                "vntheta": "Agent"
+              },
+              {
+                "number": "A1",
+                "vntheta": "Recipient"
+              },
+              {
+                "number": "A2",
+                "vntheta": "Theme"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "lemma": "postpone",
+    "mappings": [
+      {
+        "id": "postpone.01",
+        "mappings": [
+          {
+            "vncls": "53.1-1",
+            "roles": [
+              {
+                "number": "A0",
+                "vntheta": "Agent"
+              },
+              {
+                "number": "A1",
+                "vntheta": "Theme"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "lemma": "enable",
+    "mappings": [
+      {
+        "id": "enable.01",
+        "mappings": [
+          {
+            "vncls": "45.4",
+            "roles": [
+              {
+                "number": "A0",
+                "vntheta": "Agent"
+              },
+              {
+                "number": "A1",
+                "vntheta": "Patient"
+              },
+              {
+                "number": "A2",
+                "vntheta": "Result"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "lemma": "practise",
+    "mappings": [
+      {
+        "id": "practice.01",
+        "mappings": [
+          {
+            "vncls": "26.8-1",
+            "roles": [
+              {
+                "number": "A0",
+                "vntheta": "Agent"
+              },
+              {
+                "number": "A1",
+                "vntheta": "Theme"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "lemma": "subscribe",
+    "mappings": [
+      {
+        "id": "subscribe.01",
+        "mappings": [
+          {
+            "vncls": "115",
+            "roles": [
+              {
+                "number": "A0",
+                "vntheta": "Agent"
+              },
+              {
+                "number": "A1",
+                "vntheta": "Source"
               }
             ]
           }

--- a/semparse-tf4j-grpc/pom.xml
+++ b/semparse-tf4j-grpc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>semparse</artifactId>
         <groupId>io.github.semlink</groupId>
-        <version>0.0.4-SNAPSHOT</version>
+        <version>0.0.5-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/semparse-tf4j/pom.xml
+++ b/semparse-tf4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>semparse</artifactId>
         <groupId>io.github.semlink</groupId>
-        <version>0.0.4-SNAPSHOT</version>
+        <version>0.0.5-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/semparse-tf4j/src/main/java/io/github/semlink/app/TensorflowModel.java
+++ b/semparse-tf4j/src/main/java/io/github/semlink/app/TensorflowModel.java
@@ -16,9 +16,8 @@
 
 package io.github.semlink.app;
 
-import io.github.semlink.extractor.BertSrlExampleExtractor;
-import io.github.semlink.extractor.SequenceExampleExtractor;
 import org.tensorflow.SavedModelBundle;
+import org.tensorflow.Session;
 import org.tensorflow.Tensor;
 import org.tensorflow.example.SequenceExample;
 
@@ -29,6 +28,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.github.semlink.extractor.BertSrlExampleExtractor;
+import io.github.semlink.extractor.SequenceExampleExtractor;
 import io.github.semlink.extractor.config.ConfigSpec;
 import io.github.semlink.extractor.config.Extractors;
 import io.github.semlink.tensor.TensorList;
@@ -74,14 +75,22 @@ public class TensorflowModel implements AutoCloseable, SequencePredictor<HasFiel
                 .collect(Collectors.toList());
 
         try (Tensor<?> inputTensor = Tensor.create(batchExamples(sequenceExamples), String.class)) {
-            try (TensorList results = TensorList.of(model.session().runner()
+            Session.Runner runner = model.session().runner()
                     .feed(inputName, inputTensor)
-                    .fetch(fetchName)
-                    .run())) {
-                return toStringLists(results.get(0)).stream()
+                    .fetch(fetchName);
+            TensorList results;
+
+            // TODO: figure out why Session is not thread safe, fix, unsynchronize
+            synchronized (this) {
+                results = TensorList.of(runner.run());
+            }
+
+            List<List<String>> result = toStringLists(results.get(0)).stream()
                     .map(labels -> labels.stream().filter(l -> !l.equals(IGNORE_LABEL)).collect(Collectors.toList()))
                     .collect(Collectors.toList());
-            }
+
+            results.close();
+            return result;
         }
     }
 
@@ -109,7 +118,7 @@ public class TensorflowModel implements AutoCloseable, SequencePredictor<HasFiel
 
     public static TensorflowModel bertFromDirectory(@NonNull String modelDir) {
         return fromDirectory(modelDir, new BertSrlExampleExtractor(
-            new WordPieceTokenizer(Paths.get(modelDir, "model", "assets", "vocab.txt").toString())));
+                new WordPieceTokenizer(Paths.get(modelDir, "model", "assets", "vocab.txt").toString())));
     }
 
 }

--- a/semparse-web/pom.xml
+++ b/semparse-web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>semparse</artifactId>
         <groupId>io.github.semlink</groupId>
-        <version>0.0.4-SNAPSHOT</version>
+        <version>0.0.5-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/semparse-web/src/main/java/io/github/semlink/app/api/model/PropModel.java
+++ b/semparse-web/src/main/java/io/github/semlink/app/api/model/PropModel.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import io.github.semlink.app.Chunking;
-import io.github.semlink.parser.DefaultVerbNetProp;
+import io.github.semlink.parser.VerbNetProp;
 import io.github.semlink.semlink.SemlinkRole;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -51,7 +51,7 @@ public class PropModel {
     private List<EventModel> events = new ArrayList<>();
     private List<SemlinkRoleModel> spans = new ArrayList<>();
 
-    public PropModel(DefaultVerbNetProp prop) {
+    public PropModel(VerbNetProp prop) {
         this.sense = prop.proposition().predicate().verbNetId().toString();
         this.events = prop.subEvents().stream().map(EventModel::new).collect(Collectors.toList());
         this.mainEvent = prop.mainEvent().map(EventModel::new).orElse(null);

--- a/semparse-web/src/test/java/io/github/semlink/VerbNetParserTest.java
+++ b/semparse-web/src/test/java/io/github/semlink/VerbNetParserTest.java
@@ -18,15 +18,17 @@ package io.github.semlink;
 
 import io.github.clearwsd.parser.Nlp4jDependencyParser;
 import io.github.clearwsd.parser.NlpParser;
-import io.github.semlink.verbnet.DefaultVnIndex;
-import io.github.semlink.verbnet.VnIndex;
+import io.github.semlink.parser.DefaultVnPredicateDetector;
 import io.github.semlink.parser.LightVerbMapper;
 import io.github.semlink.parser.SemanticRoleLabeler;
 import io.github.semlink.parser.VerbNetParse;
 import io.github.semlink.parser.VerbNetParser;
 import io.github.semlink.parser.VerbNetSenseClassifier;
+import io.github.semlink.parser.VnPredicateDetector;
 import io.github.semlink.propbank.type.PropBankArg;
 import io.github.semlink.semlink.VerbNetAligner;
+import io.github.semlink.verbnet.DefaultVnIndex;
+import io.github.semlink.verbnet.VnIndex;
 
 import static io.github.semlink.parser.VerbNetParser.pbRoleLabeler;
 
@@ -52,9 +54,10 @@ public class VerbNetParserTest {
         LightVerbMapper verbMapper = LightVerbMapper.fromMappingsPath("semparse/lvm.tsv", verbNet);
         // aligner that uses PropBank VerbNet mappings and heuristics to align PropBank roles with VerbNet thematic roles
         VerbNetAligner aligner = VerbNetAligner.of("semparse/pbvn-mappings.json", "semparse/unified-frames.bin");
+        VnPredicateDetector predicateDetector = new DefaultVnPredicateDetector(classifier, verbMapper);
 
         // simplifying facade over the above components
-        VerbNetParser parser = new VerbNetParser(classifier, roleLabeler, aligner, verbMapper);
+        VerbNetParser parser = new VerbNetParser(predicateDetector, classifier, roleLabeler, aligner);
 
         VerbNetParse parse = parser.parse("John ate an apple");
         System.out.println(parse); // Take In[EVENT(E1 = VnClassXml(verbNetId=eat-39.1)), Agent(A0[John]), Patient(A1[an apple])]


### PR DESCRIPTION
Adds 1552 mappings for non-LVC nominalizations to VerbNet classes.

Also add a temporary fix for thread-safety issues when predicting from TF sessions.